### PR TITLE
Changes repo path in preview plugin, site footer, and other instances

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Fixes #<PUT ISSUE NUM HERE>
 
-[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/BRANCH_NAME/)
+[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/ONRR/doi-extractives-data/BRANCH_NAME/)
 
 Changes proposed in this pull request:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Fixes #<PUT ISSUE NUM HERE>
 
-[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/ONRR/doi-extractives-data/BRANCH_NAME/)
+[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/BRANCH_NAME/)
 
 Changes proposed in this pull request:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,8 @@
 ## Welcome
 
-We’re glad you’re thinking about contributing to an 18F open source project! If you’re unsure about anything, ask us — or submit the issue or pull request anyway. The worst that can happen is that we’ll politely ask you to change something.
+We’re glad you’re thinking about contributing to this open source project! If you’re unsure about anything, ask us — or submit the issue or pull request anyway. The worst that can happen is that we’ll politely ask you to change something.
 
-We love all friendly contributions, and we welcome your ideas about how to make USEITI’s online presence more user friendly, accessible, and elegant.
-
-To ensure a welcoming environment for our projects, our staff follows the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md); contributors should do the same. Please also check out the [18F Open Source Policy](https://github.com/18f/open-source-policy).
+We welcome all friendly contributions, and we welcome your ideas about how to make our online presence more user friendly, accessible, and elegant.
 
 * [Running and testing the site with Docker](#running-and-testing-the-site-with-Docker)
     - [Troubleshooting](#troubleshooting)
@@ -151,7 +149,7 @@ becomes broken and you're not sure how to fix it, run
 
 ### Data and database
 
-The [data catalog](https://github.com/18F/doi-extractives-data/wiki/Data-Catalog) explains what most of the data is and where it came from. See the [data](data/) directory for more detailed info and instructions on updating the data.
+The [data catalog](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog) explains what most of the data is and where it came from. See the [data](data/) directory for more detailed info and instructions on updating the data.
 
 Data for the site is populated via data files in the `_data` directory. These are primarily `yml` files that are generated from commands in the [`Makefile`](Makefile).
 
@@ -282,7 +280,7 @@ When you open an issue, fill out all relevant fields in the issue template and i
 
 #### Open-source contributions
 
-We welcome contributions from the open source community! If you would like to contribute, please direct your pull requests to the [`contribution`](https://github.com/18F/doi-extractives-data/tree/contribution) branch (instead of the default `dev` branch). This enables us to create a preview link for your contribution.
+We welcome contributions from the open source community! If you would like to contribute, please direct your pull requests to the [`contribution`](https://github.com/ONRR/doi-extractives-data/tree/contribution) branch (instead of the default `dev` branch). This enables us to create a preview link for your contribution.
 
 #### Creating a pull request
 
@@ -295,7 +293,7 @@ We welcome contributions from the open source community! If you would like to co
 #### Reviewing a pull request
 
 - Anyone may informally review a pull request and make comments or suggestions.
-- For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/18F/doi-extractives-data/wiki/How-to-review-a-pull-request)
+- For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/ONRR/doi-extractives-data/wiki/How-to-review-a-pull-request)
 
 #### Merging a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ becomes broken and you're not sure how to fix it, run
 
 ### Data and database
 
-The [data catalog](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog) explains what most of the data is and where it came from. See the [data](data/) directory for more detailed info and instructions on updating the data.
+The [data catalog](https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog) explains what most of the data is and where it came from. See the [data](data/) directory for more detailed info and instructions on updating the data.
 
 Data for the site is populated via data files in the `_data` directory. These are primarily `yml` files that are generated from commands in the [`Makefile`](Makefile).
 
@@ -280,7 +280,7 @@ When you open an issue, fill out all relevant fields in the issue template and i
 
 #### Open-source contributions
 
-We welcome contributions from the open source community! If you would like to contribute, please direct your pull requests to the [`contribution`](https://github.com/ONRR/doi-extractives-data/tree/contribution) branch (instead of the default `dev` branch). This enables us to create a preview link for your contribution.
+We welcome contributions from the open source community! If you would like to contribute, please direct your pull requests to the [`contribution`](https://github.com/onrr/doi-extractives-data/tree/contribution) branch (instead of the default `dev` branch). This enables us to create a preview link for your contribution.
 
 #### Creating a pull request
 
@@ -293,7 +293,7 @@ We welcome contributions from the open source community! If you would like to co
 #### Reviewing a pull request
 
 - Anyone may informally review a pull request and make comments or suggestions.
-- For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/ONRR/doi-extractives-data/wiki/How-to-review-a-pull-request)
+- For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/onrr/doi-extractives-data/wiki/How-to-review-a-pull-request)
 
 #### Merging a pull request
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![CircleCI](https://circleci.com/gh/ONRR/doi-extractives-data/tree/dev.svg?style=svg)](https://circleci.com/gh/ONRR/doi-extractives-data/tree/dev)
+[![CircleCI](https://circleci.com/gh/onrr/doi-extractives-data/tree/dev.svg?style=svg)](https://circleci.com/gh/onrr/doi-extractives-data/tree/dev)
 
 # U.S. Department of the Interior Natural Resource Revenue Data
 
-This is the repository for active development work on [revenuedata.doi.gov](https://revenuedata.doi.gov). See [releases](https://github.com/ONRR/doi-extractives-data/releases) for information about the current version of the site.
+This is the repository for active development work on [revenuedata.doi.gov](https://revenuedata.doi.gov). See [releases](https://github.com/onrr/doi-extractives-data/releases) for information about the current version of the site.
 
-**For more detailed process, development, and data information, please see our [repository's wiki](https://github.com/ONRR/doi-extractives-data/wiki).**
+**For more detailed process, development, and data information, please see our [repository's wiki](https://github.com/onrr/doi-extractives-data/wiki).**
 
 ## What
 
@@ -15,7 +15,7 @@ This repository contains the code for revenuedata.doi.gov, which is a website th
 For more information about the history of the site, see [about this site](https://revenuedata.doi.gov/about/).
 
 ## Contributing
-Content and feature suggestions are welcome via [GitHub Issues](https://github.com/18F/doi-extractives-data/issues). Code contributions are welcome via [pull request](https://help.github.com/articles/using-pull-requests/), although of course we cannot guarantee your changes will be included in the site. Take a look at the issues we've tagged [help wanted](https://github.com/ONRR/doi-extractives-data/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)!
+Content and feature suggestions are welcome via [GitHub Issues](https://github.com/18F/doi-extractives-data/issues). Code contributions are welcome via [pull request](https://help.github.com/articles/using-pull-requests/), although of course we cannot guarantee your changes will be included in the site. Take a look at the issues we've tagged [help wanted](https://github.com/onrr/doi-extractives-data/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)!
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information about how to pitch in.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/dev.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/dev)
+[![CircleCI](https://circleci.com/gh/ONRR/doi-extractives-data/tree/dev.svg?style=svg)](https://circleci.com/gh/ONRR/doi-extractives-data/tree/dev)
 
 # U.S. Department of the Interior Natural Resource Revenue Data
 
-This is the repository for active development work on [revenuedata.doi.gov](https://revenuedata.doi.gov). See [releases](https://github.com/18F/doi-extractives-data/releases) for information about the current version of the site.
+This is the repository for active development work on [revenuedata.doi.gov](https://revenuedata.doi.gov). See [releases](https://github.com/ONRR/doi-extractives-data/releases) for information about the current version of the site.
 
-**For more detailed process, development, and data information, please see our [repository's wiki](https://github.com/18F/doi-extractives-data/wiki).**
+**For more detailed process, development, and data information, please see our [repository's wiki](https://github.com/ONRR/doi-extractives-data/wiki).**
 
 ## What
 
@@ -15,7 +15,7 @@ This repository contains the code for revenuedata.doi.gov, which is a website th
 For more information about the history of the site, see [about this site](https://revenuedata.doi.gov/about/).
 
 ## Contributing
-Content and feature suggestions are welcome via [GitHub Issues](https://github.com/18F/doi-extractives-data/issues). Code contributions are welcome via [pull request](https://help.github.com/articles/using-pull-requests/), although of course we cannot guarantee your changes will be included in the site. Take a look at the issues we've tagged [help wanted](https://github.com/18F/doi-extractives-data/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)!
+Content and feature suggestions are welcome via [GitHub Issues](https://github.com/18F/doi-extractives-data/issues). Code contributions are welcome via [pull request](https://help.github.com/articles/using-pull-requests/), although of course we cannot guarantee your changes will be included in the site. Take a look at the issues we've tagged [help wanted](https://github.com/ONRR/doi-extractives-data/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)!
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information about how to pitch in.
 

--- a/_downloads/default.md
+++ b/_downloads/default.md
@@ -102,7 +102,7 @@ tag:
 <ul class="list-sections list-unstyled">
     <li class="downloads-download_links">
     <a href="http://www.eia.gov/" class="link-no_under"><h3 id="all-lands-and-waters">All lands and waters</h3></a>
-    <p>This data is from the <a href="http://www.eia.gov/">Energy Information Administration</a>. The specific data we used for the interactions is a subset of the huge amount of data available on their website. We also have <a href="https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#all-production">notes on using this data</a> from our web development team with links to the specific tables we used on this site. <em>Tip: to find data on the EIA site, click 'Sources & Uses' in the navigation near the top of the site.</em></p>
+    <p>This data is from the <a href="http://www.eia.gov/">Energy Information Administration</a>. The specific data we used for the interactions is a subset of the huge amount of data available on their website. We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#all-production">notes on using this data</a> from our web development team with links to the specific tables we used on this site. <em>Tip: to find data on the EIA site, click 'Sources & Uses' in the navigation near the top of the site.</em></p>
     <a href="http://www.eia.gov/">
       Go to EIA &#8594;
     </a>
@@ -126,14 +126,14 @@ tag:
     <li class="downloads-download_links">
     <a href="http://www.bea.gov/API/signup/index.cfm" class="link-no_under"><h3 id="gdp">Gross domestic product (GDP)</h3></a>
     <p>This data is from the <a href="http://www.bea.gov/">Bureau of Economic Analysis</a> (BEA), which measures GDP by adding up the “real value added” for each industry that contributes to the U.S. economy. According to the BEA, real value added includes “compensation of employees; taxes on production and imports, less subsidies; and gross operating surplus.”</p>
-    <p>The data we use for the interactions on this site is a subset of the data available on their website. We access this data live via an Application Programming Interface (API). Take a look at <a href="https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#gdp">notes on using this data</a> from our web development team with information on the specific API calls we use on this site.</p>
+    <p>The data we use for the interactions on this site is a subset of the data available on their website. We access this data live via an Application Programming Interface (API). Take a look at <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#gdp">notes on using this data</a> from our web development team with information on the specific API calls we use on this site.</p>
     <a href="http://www.bea.gov/API/signup/index.cfm">Go to BEA API docs &#8594;
     </a>
   </li>
 
   <li class="downloads-download_links">
     <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html" class="link-no_under"><h3 id="exports">Exports</h3></a>
-    <p>This data is from the <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html">U.S. Census Bureau</a>. It arrives in Excel format, and lists the top 25 exports for each state by <a href="http://unstats.un.org/unsd/tradekb/Knowledgebase/Harmonized-Commodity-Description-and-Coding-Systems-HS">HS6 code</a>. We also have <a href="https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#exports">notes on using this data</a> from our web development team.</p>
+    <p>This data is from the <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html">U.S. Census Bureau</a>. It arrives in Excel format, and lists the top 25 exports for each state by <a href="http://unstats.un.org/unsd/tradekb/Knowledgebase/Harmonized-Commodity-Description-and-Coding-Systems-HS">HS6 code</a>. We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#exports">notes on using this data</a> from our web development team.</p>
     <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html">Go to U.S. Census exports data page &#8594;
     </a>
   </li>
@@ -178,12 +178,12 @@ tag:
         </tr>
       </tbody>
     </table>
-    <p>The best way to get this data is from the <a href="http://www.bls.gov/cew/datatoc.htm">Quarterly Census of Employment and Wages</a>. You can download CSVs as single files and select "annual averages" (you will need to load titles). We also have <a href="https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#salary-employment">notes on using this data</a> from our web development team.</p>
+    <p>The best way to get this data is from the <a href="http://www.bls.gov/cew/datatoc.htm">Quarterly Census of Employment and Wages</a>. You can download CSVs as single files and select "annual averages" (you will need to load titles). We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#salary-employment">notes on using this data</a> from our web development team.</p>
     <a href="http://www.bls.gov/cew/datatoc.htm">Go to BLS quarterly census &#8594;
     </a>
 
     <p class="u-margin-top">The other type of jobs data we use is <em>self-employment</em>. This data describes the number of people (full-time and part-time) that are self-employed in natural resource extraction. Self-employed people don’t receive wages or salaries because they own their company, either as a sole proprietor, partnership, or small business. This data includes some double counting because people may appear on multiple tax forms.</p>
-    <p>Self-employment data comes from comes from the <a href="http://www.bea.gov/">Bureau of Economic Analysis</a>, or BEA, but must be calculated, by subtracting SA27N Full- and Part-Time Wage and Salary Employment by {{ "NAICS" | term:"north american industry classification system (naics)" }} Industry from SA25N Full- and Part-Time Employment by NAICS Industry. We also have <a href="https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#self-employment">notes on using this data</a> from our web development team.</p>
+    <p>Self-employment data comes from comes from the <a href="http://www.bea.gov/">Bureau of Economic Analysis</a>, or BEA, but must be calculated, by subtracting SA27N Full- and Part-Time Wage and Salary Employment by {{ "NAICS" | term:"north american industry classification system (naics)" }} Industry from SA25N Full- and Part-Time Employment by NAICS Industry. We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#self-employment">notes on using this data</a> from our web development team.</p>
     <a href="http://www.bea.gov/">Go to BEA &#8594;
     </a>
   </li>

--- a/_downloads/default.md
+++ b/_downloads/default.md
@@ -102,7 +102,7 @@ tag:
 <ul class="list-sections list-unstyled">
     <li class="downloads-download_links">
     <a href="http://www.eia.gov/" class="link-no_under"><h3 id="all-lands-and-waters">All lands and waters</h3></a>
-    <p>This data is from the <a href="http://www.eia.gov/">Energy Information Administration</a>. The specific data we used for the interactions is a subset of the huge amount of data available on their website. We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#all-production">notes on using this data</a> from our web development team with links to the specific tables we used on this site. <em>Tip: to find data on the EIA site, click 'Sources & Uses' in the navigation near the top of the site.</em></p>
+    <p>This data is from the <a href="http://www.eia.gov/">Energy Information Administration</a>. The specific data we used for the interactions is a subset of the huge amount of data available on their website. We also have <a href="https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#all-production">notes on using this data</a> from our web development team with links to the specific tables we used on this site. <em>Tip: to find data on the EIA site, click 'Sources & Uses' in the navigation near the top of the site.</em></p>
     <a href="http://www.eia.gov/">
       Go to EIA &#8594;
     </a>
@@ -126,14 +126,14 @@ tag:
     <li class="downloads-download_links">
     <a href="http://www.bea.gov/API/signup/index.cfm" class="link-no_under"><h3 id="gdp">Gross domestic product (GDP)</h3></a>
     <p>This data is from the <a href="http://www.bea.gov/">Bureau of Economic Analysis</a> (BEA), which measures GDP by adding up the “real value added” for each industry that contributes to the U.S. economy. According to the BEA, real value added includes “compensation of employees; taxes on production and imports, less subsidies; and gross operating surplus.”</p>
-    <p>The data we use for the interactions on this site is a subset of the data available on their website. We access this data live via an Application Programming Interface (API). Take a look at <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#gdp">notes on using this data</a> from our web development team with information on the specific API calls we use on this site.</p>
+    <p>The data we use for the interactions on this site is a subset of the data available on their website. We access this data live via an Application Programming Interface (API). Take a look at <a href="https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#gdp">notes on using this data</a> from our web development team with information on the specific API calls we use on this site.</p>
     <a href="http://www.bea.gov/API/signup/index.cfm">Go to BEA API docs &#8594;
     </a>
   </li>
 
   <li class="downloads-download_links">
     <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html" class="link-no_under"><h3 id="exports">Exports</h3></a>
-    <p>This data is from the <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html">U.S. Census Bureau</a>. It arrives in Excel format, and lists the top 25 exports for each state by <a href="http://unstats.un.org/unsd/tradekb/Knowledgebase/Harmonized-Commodity-Description-and-Coding-Systems-HS">HS6 code</a>. We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#exports">notes on using this data</a> from our web development team.</p>
+    <p>This data is from the <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html">U.S. Census Bureau</a>. It arrives in Excel format, and lists the top 25 exports for each state by <a href="http://unstats.un.org/unsd/tradekb/Knowledgebase/Harmonized-Commodity-Description-and-Coding-Systems-HS">HS6 code</a>. We also have <a href="https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#exports">notes on using this data</a> from our web development team.</p>
     <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html">Go to U.S. Census exports data page &#8594;
     </a>
   </li>
@@ -178,12 +178,12 @@ tag:
         </tr>
       </tbody>
     </table>
-    <p>The best way to get this data is from the <a href="http://www.bls.gov/cew/datatoc.htm">Quarterly Census of Employment and Wages</a>. You can download CSVs as single files and select "annual averages" (you will need to load titles). We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#salary-employment">notes on using this data</a> from our web development team.</p>
+    <p>The best way to get this data is from the <a href="http://www.bls.gov/cew/datatoc.htm">Quarterly Census of Employment and Wages</a>. You can download CSVs as single files and select "annual averages" (you will need to load titles). We also have <a href="https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#salary-employment">notes on using this data</a> from our web development team.</p>
     <a href="http://www.bls.gov/cew/datatoc.htm">Go to BLS quarterly census &#8594;
     </a>
 
     <p class="u-margin-top">The other type of jobs data we use is <em>self-employment</em>. This data describes the number of people (full-time and part-time) that are self-employed in natural resource extraction. Self-employed people don’t receive wages or salaries because they own their company, either as a sole proprietor, partnership, or small business. This data includes some double counting because people may appear on multiple tax forms.</p>
-    <p>Self-employment data comes from comes from the <a href="http://www.bea.gov/">Bureau of Economic Analysis</a>, or BEA, but must be calculated, by subtracting SA27N Full- and Part-Time Wage and Salary Employment by {{ "NAICS" | term:"north american industry classification system (naics)" }} Industry from SA25N Full- and Part-Time Employment by NAICS Industry. We also have <a href="https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#self-employment">notes on using this data</a> from our web development team.</p>
+    <p>Self-employment data comes from comes from the <a href="http://www.bea.gov/">Bureau of Economic Analysis</a>, or BEA, but must be calculated, by subtracting SA27N Full- and Part-Time Wage and Salary Employment by {{ "NAICS" | term:"north american industry classification system (naics)" }} Industry from SA25N Full- and Part-Time Employment by NAICS Industry. We also have <a href="https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#self-employment">notes on using this data</a> from our web development team.</p>
     <a href="http://www.bea.gov/">Go to BEA &#8594;
     </a>
   </li>

--- a/_downloads/disbursements.md
+++ b/_downloads/disbursements.md
@@ -46,7 +46,7 @@ Download fiscal year data:
 
 The documentation that follows is for the funds overview dataset. LWCF documentation is included in its download file, and we're working on collecting documentation for the NHPA dataset.
 
-We also have [notes on this data](https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#disbursements) from the web development team as they built the interactions on this site.
+We also have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#disbursements) from the web development team as they built the interactions on this site.
 
 ## Scope
 

--- a/_downloads/disbursements.md
+++ b/_downloads/disbursements.md
@@ -46,7 +46,7 @@ Download fiscal year data:
 
 The documentation that follows is for the funds overview dataset. LWCF documentation is included in its download file, and we're working on collecting documentation for the NHPA dataset.
 
-We also have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#disbursements) from the web development team as they built the interactions on this site.
+We also have [notes on this data](https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#disbursements) from the web development team as they built the interactions on this site.
 
 ## Scope
 

--- a/_downloads/federal-production.md
+++ b/_downloads/federal-production.md
@@ -63,7 +63,7 @@ tag:
 
 This dataset also includes county-level data about coal production on federal land.
 
-We have [notes on this data](https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#federal-production) from the web development team as they built the interactions on this site.
+We have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#federal-production) from the web development team as they built the interactions on this site.
 
 ## Scope
 

--- a/_downloads/federal-production.md
+++ b/_downloads/federal-production.md
@@ -63,7 +63,7 @@ tag:
 
 This dataset also includes county-level data about coal production on federal land.
 
-We have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#federal-production) from the web development team as they built the interactions on this site.
+We have [notes on this data](https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#federal-production) from the web development team as they built the interactions on this site.
 
 ## Scope
 

--- a/_downloads/federal-revenue-by-company.md
+++ b/_downloads/federal-revenue-by-company.md
@@ -53,7 +53,7 @@ tag:
   </ul>
 </p>
 
-We also have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#company-revenue) from the web development team as they built the interactions on this site.
+We also have [notes on this data](https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#company-revenue) from the web development team as they built the interactions on this site.
 
 ## Scope
 

--- a/_downloads/federal-revenue-by-company.md
+++ b/_downloads/federal-revenue-by-company.md
@@ -53,7 +53,7 @@ tag:
   </ul>
 </p>
 
-We also have [notes on this data](https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#company-revenue) from the web development team as they built the interactions on this site.
+We also have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#company-revenue) from the web development team as they built the interactions on this site.
 
 ## Scope
 

--- a/_downloads/federal-revenue-by-location.md
+++ b/_downloads/federal-revenue-by-location.md
@@ -76,7 +76,7 @@ Download fiscal year data:
   </a></li>
 </ul>
 
-<p class="u-margin-top" markdown="1">We also have [notes on this data](https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#federal-revenue) from the web development team as they built the interactions on this site.</p>
+<p class="u-margin-top" markdown="1">We also have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#federal-revenue) from the web development team as they built the interactions on this site.</p>
 
 ## Scope
 

--- a/_downloads/federal-revenue-by-location.md
+++ b/_downloads/federal-revenue-by-location.md
@@ -76,7 +76,7 @@ Download fiscal year data:
   </a></li>
 </ul>
 
-<p class="u-margin-top" markdown="1">We also have [notes on this data](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#federal-revenue) from the web development team as they built the interactions on this site.</p>
+<p class="u-margin-top" markdown="1">We also have [notes on this data](https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#federal-revenue) from the web development team as they built the interactions on this site.</p>
 
 ## Scope
 

--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -8,7 +8,7 @@
 
       <div class="footer-bottom-left">
 	      <p class="footer-para_callout footer-para_callout-bigger">Built in the open</p>
-	      <p class="footer-para">This site (<a href="https://github.com/18F/doi-extractives-data/releases/{{ site.version }}" class="link-active-beta">{{ site.version }}</a>) is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">open data</a> and <a class="link-active-beta" href="https://github.com/18F/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/18F/doi-extractives-data/issues/new">GitHub</a>.</p>
+	      <p class="footer-para">This site (<a href="https://github.com/ONRR/doi-extractives-data/releases/{{ site.version }}" class="link-active-beta">{{ site.version }}</a>) is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">open data</a> and <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/issues/new">GitHub</a>.</p>
 
         <p class="footer-para-small footer-para_last"><a href="https://www.doi.gov/" class="link-beta">Department of the Interior</a> | <a href="https://www.doi.gov/privacy" class="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" class="link-beta">FOIA</a> | <a href="https://www.usa.gov/" class="link-beta">USA.gov</a></p>
 

--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -8,7 +8,7 @@
 
       <div class="footer-bottom-left">
 	      <p class="footer-para_callout footer-para_callout-bigger">Built in the open</p>
-	      <p class="footer-para">This site (<a href="https://github.com/ONRR/doi-extractives-data/releases/{{ site.version }}" class="link-active-beta">{{ site.version }}</a>) is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">open data</a> and <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/issues/new">GitHub</a>.</p>
+	      <p class="footer-para">This site (<a href="https://github.com/onrr/doi-extractives-data/releases/{{ site.version }}" class="link-active-beta">{{ site.version }}</a>) is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">open data</a> and <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/issues/new">GitHub</a>.</p>
 
         <p class="footer-para-small footer-para_last"><a href="https://www.doi.gov/" class="link-beta">Department of the Interior</a> | <a href="https://www.doi.gov/privacy" class="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" class="link-beta">FOIA</a> | <a href="https://www.usa.gov/" class="link-beta">USA.gov</a></p>
 

--- a/_plugins/federalist-preview.rb
+++ b/_plugins/federalist-preview.rb
@@ -5,7 +5,7 @@ module Jekyll
       # Federalist preview URL for this branch.
       branch = ENV['BRANCH']
       if branch && branch != 'master'
-        site.config['url'] = "https://federalist.fr.cloud.gov/preview/ONRR/doi-extractives-data/#{branch}"
+        site.config['url'] = "https://federalist.fr.cloud.gov/preview/onrr/doi-extractives-data/#{branch}"
         puts "*** Federalist URL: <#{site.config['url']}> ***"
       end
     end

--- a/_plugins/federalist-preview.rb
+++ b/_plugins/federalist-preview.rb
@@ -5,7 +5,7 @@ module Jekyll
       # Federalist preview URL for this branch.
       branch = ENV['BRANCH']
       if branch && branch != 'master'
-        site.config['url'] = "https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/#{branch}"
+        site.config['url'] = "https://federalist.fr.cloud.gov/preview/ONRR/doi-extractives-data/#{branch}"
         puts "*** Federalist URL: <#{site.config['url']}> ***"
       end
     end

--- a/_sass/blocks/_banner.scss
+++ b/_sass/blocks/_banner.scss
@@ -6,7 +6,7 @@
 // Markup:
 // <section class="banner slab-beta">
 //   <span class="banner-left">An official website of the U.S. Government <img class="banner-image" src="{{ site.baseurl }}/public/img/us-flag-small.png" alt="U.S. flag signifying that this is a United States Federal Government website"></span>
-//   <span class="banner-right">This site is in development. <a class="link-alpha" title="Learn about this site's development" tabindex="0" href="https://github.com/ONRR/doi-extractives-data/issues/">See what's new</a>.</span>
+//   <span class="banner-right">This site is in development. <a class="link-alpha" title="Learn about this site's development" tabindex="0" href="https://github.com/onrr/doi-extractives-data/issues/">See what's new</a>.</span>
 // </section>
 //
 // Styleguide blocks.banner

--- a/_sass/blocks/_banner.scss
+++ b/_sass/blocks/_banner.scss
@@ -1,13 +1,12 @@
-// US Bar Disclaimer Banner
+// U.S. Bar Disclaimer Banner
 //
-// This is the banner that lives at the top of every page.
-// It links people to our github issues so that we can get
-// input from the American people.
+// This banner lives at the top of every page and identifies the site as an official government
+// website.
 //
 // Markup:
 // <section class="banner slab-beta">
-//   <span class="banner-left">An official website of the US Government <img class="banner-image" src="{{ site.baseurl }}/public/img/us-flag-small.png" alt="US flag signifying that this is a United States Federal Government website"></span>
-//   <span class="banner-right">This site is in development. <a class="link-alpha" title="Learn about this site's development" tabindex="0" href="https://github.com/18F/doi-extractives-data/issues/">See what's new</a>.</span>
+//   <span class="banner-left">An official website of the U.S. Government <img class="banner-image" src="{{ site.baseurl }}/public/img/us-flag-small.png" alt="U.S. flag signifying that this is a United States Federal Government website"></span>
+//   <span class="banner-right">This site is in development. <a class="link-alpha" title="Learn about this site's development" tabindex="0" href="https://github.com/ONRR/doi-extractives-data/issues/">See what's new</a>.</span>
 // </section>
 //
 // Styleguide blocks.banner

--- a/data/README.md
+++ b/data/README.md
@@ -25,9 +25,9 @@ Much of the data that we encounter is made available to us as a Microsoft Excel 
 ruby scripts/csv_tsv.rb path/to/csv.csv /path/to/new/tsv.tsv
 ```
 
-**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/18F/doi-extractives-data/tree/master/data/company-revenue) instead.
+**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/ONRR/doi-extractives-data/tree/master/data/company-revenue) instead.
 
-**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/18F/doi-extractives-data/tree/master/data/company-revenue) instead.
+**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/ONRR/doi-extractives-data/tree/master/data/company-revenue) instead.
 
 Check out the [Makefile](Makefile) and the [bin directory](bin/) if you want to
 see how the sausage is made.
@@ -49,7 +49,7 @@ npm test
 
 **Note**: If the tests fail, it is likely that you will need to update the pivot table (generally a file prefixed with `pivot-`) for that data. Read instructions on [creating a pivot table](Create-pivot-table.md).
 
-See [this issue](https://github.com/18F/doi-extractives-data/issues/493) for
+See [this issue](https://github.com/ONRR/doi-extractives-data/issues/493) for
 some background on what we're aiming to do here. Progress on importing all of
 the data we need is tracked in
-[this issue](https://github.com/18F/doi-extractives-data/issues/496).
+[this issue](https://github.com/ONRR/doi-extractives-data/issues/496).

--- a/data/README.md
+++ b/data/README.md
@@ -25,9 +25,9 @@ Much of the data that we encounter is made available to us as a Microsoft Excel 
 ruby scripts/csv_tsv.rb path/to/csv.csv /path/to/new/tsv.tsv
 ```
 
-**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/ONRR/doi-extractives-data/tree/master/data/company-revenue) instead.
+**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/onrr/doi-extractives-data/tree/master/data/company-revenue) instead.
 
-**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/ONRR/doi-extractives-data/tree/master/data/company-revenue) instead.
+**Note**: One dataset, company revenue, is handled directly as a tsv. To update this dataset, follow the directions [here](https://github.com/onrr/doi-extractives-data/tree/master/data/company-revenue) instead.
 
 Check out the [Makefile](Makefile) and the [bin directory](bin/) if you want to
 see how the sausage is made.
@@ -49,7 +49,7 @@ npm test
 
 **Note**: If the tests fail, it is likely that you will need to update the pivot table (generally a file prefixed with `pivot-`) for that data. Read instructions on [creating a pivot table](Create-pivot-table.md).
 
-See [this issue](https://github.com/ONRR/doi-extractives-data/issues/493) for
+See [this issue](https://github.com/onrr/doi-extractives-data/issues/493) for
 some background on what we're aiming to do here. Progress on importing all of
 the data we need is tracked in
-[this issue](https://github.com/ONRR/doi-extractives-data/issues/496).
+[this issue](https://github.com/onrr/doi-extractives-data/issues/496).

--- a/data/disbursements/README.md
+++ b/data/disbursements/README.md
@@ -2,15 +2,15 @@
 
 This directory contains data concerning federal revenue disbursements
 to various federal and state entities such as parks and conservation funds.
-This data was provided to 18F by the [Department of the Interior][DOI].
+This data comes from the [Department of the Interior][DOI].
 
 * `county-level.tsv` details all federal disbursements from 2012 to 2017,
   by state or fund, county within states, and includes [Historic
   Preservation Fund][HPF] disbursements. This is the main disbursements file
-  received from ONNR.
+  received from the Office of Natural Resources Revenue.
 * `historic-preservation.tsv` more specifically details disbursements to
   the [Historic Preservation Fund (HPF)][HPF], organized by year and state.
-* The [lwcf directory](lwcf/) contains more specific data about the
+* The [`lwcf directory`](lwcf/) contains more specific data about the
   [Land and Water Conservation Fund (LWCF)][LWCF]. See that directory's
   [README](lwcf/#readme) for more information.
 
@@ -23,7 +23,7 @@ county-level, historic preservation and lwcf data to be used by the site:
    data updates.
 * `federal-pivot.tsv` is a generated file that pulls in different values for
    the total disbursements added up. This only needs to be updated if data
-   tests fail. See [Create pivotal table](https://github.com/18F/doi-extractives-data/blob/dev/data/Create-pivot-table.md) for more information.
+   tests fail. See [Create pivotal table](https://github.com/ONRR/doi-extractives-data/blob/dev/data/Create-pivot-table.md) for more information.
 * `tranform-*.js` all transform parts of the information, such as column names.
    They do not need to be edited for data updates.
 

--- a/data/disbursements/README.md
+++ b/data/disbursements/README.md
@@ -23,7 +23,7 @@ county-level, historic preservation and lwcf data to be used by the site:
    data updates.
 * `federal-pivot.tsv` is a generated file that pulls in different values for
    the total disbursements added up. This only needs to be updated if data
-   tests fail. See [Create pivotal table](https://github.com/ONRR/doi-extractives-data/blob/dev/data/Create-pivot-table.md) for more information.
+   tests fail. See [Create pivotal table](https://github.com/onrr/doi-extractives-data/blob/dev/data/Create-pivot-table.md) for more information.
 * `tranform-*.js` all transform parts of the information, such as column names.
    They do not need to be edited for data updates.
 

--- a/data/gdp/README.md
+++ b/data/gdp/README.md
@@ -12,8 +12,8 @@ This directory contains data and tools for updating it from the [BEA] [API].
   export BEA_API_KEY="your-key-here"
   ```
 
-1. Ensure the year range is set properly in the API [script to get data](https://github.com/ONRR/doi-extractives-data/blob/842b9c54646bd7c3b891a65b8a30bc0d57c85b4e/data/gdp/get-bea-data.js#L15)
-   and the [script to get regional data](https://github.com/ONRR/doi-extractives-data/blob/842b9c54646bd7c3b891a65b8a30bc0d57c85b4e/data/gdp/get-bea-regional.js#L8).
+1. Ensure the year range is set properly in the API [script to get data](https://github.com/onrr/doi-extractives-data/blob/842b9c54646bd7c3b891a65b8a30bc0d57c85b4e/data/gdp/get-bea-data.js#L15)
+   and the [script to get regional data](https://github.com/onrr/doi-extractives-data/blob/842b9c54646bd7c3b891a65b8a30bc0d57c85b4e/data/gdp/get-bea-regional.js#L8).
    For instance, if you are adding 2017 data, you should change both of these values to `2008-2017`.
 
 2. Next, run:

--- a/data/gdp/README.md
+++ b/data/gdp/README.md
@@ -12,17 +12,16 @@ This directory contains data and tools for updating it from the [BEA] [API].
   export BEA_API_KEY="your-key-here"
   ```
 
-1. Ensure that the year range is set properly in the API scripts:
-   [here](https://github.com/18F/doi-extractives-data/blob/data-update-docs/data/gdp/get-bea-data.js#L15)
-   and [here](https://github.com/18F/doi-extractives-data/blob/data-update-docs/data/gdp/get-bea-regional.js#L8).
-   For instance, if you are adding 2016 data, you should change both of these values to `2007-2016`.
-   
-1. Next, run:
+1. Ensure the year range is set properly in the API [script to get data](https://github.com/ONRR/doi-extractives-data/blob/842b9c54646bd7c3b891a65b8a30bc0d57c85b4e/data/gdp/get-bea-data.js#L15)
+   and the [script to get regional data](https://github.com/ONRR/doi-extractives-data/blob/842b9c54646bd7c3b891a65b8a30bc0d57c85b4e/data/gdp/get-bea-regional.js#L8).
+   For instance, if you are adding 2017 data, you should change both of these values to `2008-2017`.
+
+2. Next, run:
 
   ```sh
   make -B
   ```
-  
+
 If all goes well, this will get all the new data from BEA and update the `US.tsv` and `regional.tsv` files.
 You can confirm whether any of the data was changed by running:
 

--- a/data/revenue/README.md
+++ b/data/revenue/README.md
@@ -8,7 +8,7 @@ This directory contains data for federal revenue collected by the
   The columns are:
   * `Land Category`: always "Federal Offshore"
   * `CY`: i.e. "Calendar Year"
-  * `Offshore Region`: see [this map](https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#offshore-areas)
+  * `Offshore Region`: see [this map](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#offshore-areas)
   * `Offshore Planning Area`: the sub-area of the offshore region
   * `BOEM Block Name`: ?
   * `BOEM Protraction`: the lowest level of geographic detail. See [BOEM's protraction diagrams](https://www.boem.gov/Official-Protraction-Diagrams/) for more info.

--- a/data/revenue/README.md
+++ b/data/revenue/README.md
@@ -8,7 +8,7 @@ This directory contains data for federal revenue collected by the
   The columns are:
   * `Land Category`: always "Federal Offshore"
   * `CY`: i.e. "Calendar Year"
-  * `Offshore Region`: see [this map](https://github.com/ONRR/doi-extractives-data/wiki/Data-Catalog#offshore-areas)
+  * `Offshore Region`: see [this map](https://github.com/onrr/doi-extractives-data/wiki/Data-Catalog#offshore-areas)
   * `Offshore Planning Area`: the sub-area of the offshore region
   * `BOEM Block Name`: ?
   * `BOEM Protraction`: the lowest level of geographic detail. See [BOEM's protraction diagrams](https://www.boem.gov/Official-Protraction-Diagrams/) for more info.

--- a/nrrd-design-system/components/components/global-footer/global-footer.hbs
+++ b/nrrd-design-system/components/components/global-footer/global-footer.hbs
@@ -8,7 +8,7 @@
 
       <div class="footer-bottom-left">
         <p class="footer-para_callout footer-para_callout-bigger">Built in the open</p>
-        <p class="footer-para">This site (<a href="https://github.com/ONRR/doi-extractives-data/releases/v3.1.0" class="link-active-beta">v3.1.0</a>) is powered by open <a class="link-active-beta" href="/downloads">data</a> and <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/issues/new">GitHub</a>.</p>
+        <p class="footer-para">This site (<a href="https://github.com/onrr/doi-extractives-data/releases/v3.1.0" class="link-active-beta">v3.1.0</a>) is powered by open <a class="link-active-beta" href="/downloads">data</a> and <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/issues/new">GitHub</a>.</p>
 
         <p class="footer-para-small footer-para_last"><a href="https://www.doi.gov/" class="link-beta">Department of the Interior</a> | <a href="https://www.doi.gov/privacy" class="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" class="link-beta">FOIA</a> | <a href="https://www.usa.gov/" class="link-beta">USA.gov</a></p>
 

--- a/nrrd-design-system/components/components/global-footer/global-footer.hbs
+++ b/nrrd-design-system/components/components/global-footer/global-footer.hbs
@@ -8,7 +8,7 @@
 
       <div class="footer-bottom-left">
         <p class="footer-para_callout footer-para_callout-bigger">Built in the open</p>
-        <p class="footer-para">This site (<a href="https://github.com/18F/doi-extractives-data/releases/v3.1.0" class="link-active-beta">v3.1.0</a>) is powered by open <a class="link-active-beta" href="/downloads">data</a> and <a class="link-active-beta" href="https://github.com/18F/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/18F/doi-extractives-data/issues/new">GitHub</a>.</p>
+        <p class="footer-para">This site (<a href="https://github.com/ONRR/doi-extractives-data/releases/v3.1.0" class="link-active-beta">v3.1.0</a>) is powered by open <a class="link-active-beta" href="/downloads">data</a> and <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/issues/new">GitHub</a>.</p>
 
         <p class="footer-para-small footer-para_last"><a href="https://www.doi.gov/" class="link-beta">Department of the Interior</a> | <a href="https://www.doi.gov/privacy" class="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" class="link-beta">FOIA</a> | <a href="https://www.usa.gov/" class="link-beta">USA.gov</a></p>
 

--- a/nrrd-design-system/components/components/hero-ribbons/hero-ribbons.hbs
+++ b/nrrd-design-system/components/components/hero-ribbons/hero-ribbons.hbs
@@ -33,7 +33,7 @@
               <li><a href="#">List item</a></li>
               <li><a href="#">List item</a></li>
             </ul>
-            <a href="/preview/18f/doi-extractives-data/typography-normalizing-1/how-it-works/" class="button-primary">How it works</a>
+            <a href="/preview/ONRR/doi-extractives-data/typography-normalizing-1/how-it-works/" class="button-primary">How it works</a>
         </div>
       </div>
   	</div>
@@ -68,7 +68,7 @@
     </svg>
       </div>
       <div class="ribbon-card-bottom">
-        <a href="/preview/18f/doi-extractives-data/typography-normalizing-1/how-it-works/production/" class="link-alpha">Link to interesting section content</a>
+        <a href="/preview/ONRR/doi-extractives-data/typography-normalizing-1/how-it-works/production/" class="link-alpha">Link to interesting section content</a>
       </div>
     </div>
   </section>

--- a/nrrd-design-system/components/components/hero-ribbons/hero-ribbons.hbs
+++ b/nrrd-design-system/components/components/hero-ribbons/hero-ribbons.hbs
@@ -33,7 +33,7 @@
               <li><a href="#">List item</a></li>
               <li><a href="#">List item</a></li>
             </ul>
-            <a href="/preview/ONRR/doi-extractives-data/typography-normalizing-1/how-it-works/" class="button-primary">How it works</a>
+            <a href="/preview/onrr/doi-extractives-data/typography-normalizing-1/how-it-works/" class="button-primary">How it works</a>
         </div>
       </div>
   	</div>
@@ -68,7 +68,7 @@
     </svg>
       </div>
       <div class="ribbon-card-bottom">
-        <a href="/preview/ONRR/doi-extractives-data/typography-normalizing-1/how-it-works/production/" class="link-alpha">Link to interesting section content</a>
+        <a href="/preview/onrr/doi-extractives-data/typography-normalizing-1/how-it-works/production/" class="link-alpha">Link to interesting section content</a>
       </div>
     </div>
   </section>

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
 	"homepage": "https://revenuedata.doi.gov/",
 	"author": "ONRR",
 	"license": "CC0-1.0",
-	"repository": "github:ONRR/doi-extractives-data",
+	"repository": "github:onrr/doi-extractives-data",
 	"bugs": {
-		"url": "https://github.com/ONRR/doi-extractives-data/issues"
+		"url": "https://github.com/onrr/doi-extractives-data/issues"
 	},
 	"engines": {
 		"node": ">=8"


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/repo-transfer/)

Changes proposed in this pull request:

- Changes Ruby plugin for preview path to ONRR org
- Updates github paths to new org location