### PR TITLE
Replaces homepage world ranking text with vision-derived statement

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ selector: location
   <div class="container-page-wrapper">
 
     <div class="container-left-3">
-      <h4>The U.S. ranks first in the world for production of oil and natural gas, and second in the world for production of coal and renewable energy.</h4>
+      <h4>Learn about how the government manages federal energy and mineral resources, revenue, and disbursements.</h4>
     </div>
 
     <div class="container-left-9">

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ selector: location
   <div class="container-page-wrapper">
 
     <div class="container-left-3">
-      <h4>Learn about how the government manages federal energy and mineral resources, revenue, and disbursements.</h4>
+      <h4 id="context-cards">Learn about how the government manages federal energy and mineral resources, revenue, and disbursements.</h4>
     </div>
 
     <div class="container-left-9">


### PR DESCRIPTION
[:pencil: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/context-statement/#context-cards)

Changes proposed in this pull request:

- Replaces "world ranking" sentence on homepage
  - U.S. world ranking for coal is possibly out of date (some data sources list the U.S. third globally, not second)
  - The updated site vision is focused on how the federal government manages extraction on federal land, not how the U.S. ranks globally for all extractives production
