### PR TITLE
Bump node on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     - sudo rm -rf /home/travis
     - sudo ln -s /home/ubuntu /home/travis
   node:
-    version: 5.12.0
+    version: 8.11.3
   ruby:
     version:
       2.5.0


### PR DESCRIPTION
Use an LTS version, same as in the docker container (8.x).