### PR TITLE
Add styleguide-theme.css to override the theme

### DIFF
--- a/css/styleguide-theme.scss
+++ b/css/styleguide-theme.scss
@@ -1,0 +1,30 @@
+/* styleguide-theme.scss
+ * 
+ * This contains styles to override the styleguide theme itself, header,
+ * panels, documentation etc.
+ */
+
+@import 'variables';
+@import 'mixins/type-mixins';
+
+.Header {
+  background-color: $gray-darker;
+}
+
+.Frame-panel--sidebar {
+  background-color: $gray-pale;
+}
+
+a {
+  border: none;
+  color: $blue;
+  cursor: pointer;
+  transition: color 0.1s linear;
+
+  &:active,
+  &:hover {
+    color: $blue;
+    text-decoration: none;
+  }
+}
+

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -1,4 +1,7 @@
-/*Global*/
+/* styleguide.scss
+ *
+ * This contains additional styles needed for the styleguide to display our components properly.
+ */
 
 @import 'variables';
 

--- a/nrrd-design-system/fractal.js
+++ b/nrrd-design-system/fractal.js
@@ -8,7 +8,7 @@ const mandelbrot = require('@frctl/mandelbrot')
 const customTheme = mandelbrot({
   skin: 'blue',
   panels: ['notes', 'html', 'view', 'context', 'resources', 'info'],
-  styles: ['default', '/css/styleguide.css'],
+  styles: ['default', '/css/styleguide-theme.css'],
 })
 
 fractal.set('project.title', 'NRRD Design System')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ var cssConfig = {
     main: './css/main.scss',
     print: './css/print.scss',
     styleguide: './css/styleguide.scss',
+    'styleguide-theme': './css/styleguide-theme.scss',
   },
   output: {
     path: path.join(__dirname, '/public/css'),


### PR DESCRIPTION
Fixes #2484 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/styleguide-theme/styleguide/)

Changes proposed in this pull request:

- Adds some very basic styling to the styleguide to give it a more branded feel.
