### PR TITLE
Edits search intro copy and tweaks layout

### DIFF
--- a/_sass/blocks/_search.scss
+++ b/_sass/blocks/_search.scss
@@ -8,14 +8,6 @@
 .search-header {
   display: block;
   width: 100%;
-
-  p {
-    flex-grow: 1;
-
-    &:last-of-type {
-      text-align: right;
-    }
-  }
 }
 
 .search-wrapper {

--- a/pages/search-results.html
+++ b/pages/search-results.html
@@ -8,20 +8,9 @@ permalink: /search-results/
   <div class="container-left-8">
     <h1>{{page.title}}</h1>
 
-    <p class="search-intro">This is a curated search.<br/> Results are drawn from related websites across the U.S. government so  you can find extractive industries resources in one place.</p>
+    <p class="search-intro">Search results are drawn from across this site. If you're looking for the definition of a term, you can also <a href="javascript:void(0)" class="js-glossary-toggle" alt="this is the glossary drawer">check our glossary</a>.</p>
 
     <div class="search-results-container">
-
-      <div class="search-no-results" style="display:none;">
-        <p><strong>Sorry, no results were found for your search.</strong></p>
-      </div>
-
-      <div class="search-header">
-        <div class="search-wrapper">
-        <p>Search results for <strong class='search-string'></strong></p>
-        <p class="search-results-count"></p>
-        </div>
-      </div>
 
       <div class="search-container">
         <form action="{{ site.baseurl }}/search-results/" method="get">
@@ -31,13 +20,24 @@ permalink: /search-results/
         </form>
       </div>
 
+      <div class="search-header">
+        <div class="search-wrapper">
+        <p>Search results for <strong class='search-string'></strong></p><p>:&nbsp;</p>
+        <p class="search-results-count"></p>
+        </div>
+      </div>
+
+      <div class="search-no-results" style="display:none;">
+        <p><strong>Sorry, no results were found for your search.</strong></p>
+      </div>
+
       <div class="search-results-container"></div>
 
       <div class="search-no-results" style="display:none;">
-        <p>Try one of these popular searches
-          / <a href="../search-results/?q=energy" title="Search for energy">energy</a> /
+        <p>Try one of these popular searches:
+          <a href="../search-results/?q=energy" title="Search for energy">energy</a> /
           <a href="../search-results/?q=oil" title="Search for oil">oil</a> /
-          <a href="../search-results/?q=conservation" title="Search for conservation">conservation</a> /
+          <a href="../search-results/?q=gomesa" title="Search for gomesa">GOMESA</a> /
         </p>
       </div>
     </div>


### PR DESCRIPTION
Fixes #3055 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/search-copy/search-results/)

Changes proposed in this pull request:

- Changes search intro content to reflect site search (instead of curated search)
- Adds link to glossary if user simply wants to define a term
- Cleans up excessive spacing for number of results
- Positions number of results below search field instead of above

## Production
![image](https://user-images.githubusercontent.com/32855580/42659226-7b11eb0e-85dc-11e8-8942-fba06363cf8f.png)

## This branch
![search results layout](https://user-images.githubusercontent.com/32855580/42659181-573a5914-85dc-11e8-9d34-a02774eb7539.png)