### PR TITLE
Tweaks production subheading to remove "nationwide" and include "waters"

### DIFF
--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -13,7 +13,7 @@
 
     {%
       include sticky-header.html
-      header_text='Production on federal land nationwide'
+      header_text='Production on federal lands and waters'
       year_range=year_range
       selector=true
     %}


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/microcopy/explore/#federal-production)

Changes proposed in this pull request:

- Attempts to clarify transition from nationwide (all) production to federal production by removing "nationwide" from federal production subheading and add "waters"
