### PR TITLE
Round one of tag updates; redirect and year updates

### DIFF
--- a/_data/years.yml
+++ b/_data/years.yml
@@ -1,5 +1,5 @@
 # XXX this must be a string to use it as an index into other data!
-now: 2016
+now: 2018
 
 default: [2007, 2016]
 

--- a/_how-it-works/federal-revenue-by-company/index.html
+++ b/_how-it-works/federal-revenue-by-company/index.html
@@ -1,5 +1,5 @@
 ---
 layout: redirect
 permalink: /how-it-works/federal-revenue-by-company/
-redirect_url: /how-it-works/federal-revenue-by-company/2015/
+redirect_url: /how-it-works/federal-revenue-by-company/2016/
 ---

--- a/_how-it-works/nonenergy-minerals.md
+++ b/_how-it-works/nonenergy-minerals.md
@@ -26,7 +26,7 @@ description: Nonenergy minerals include base and precious metals, industrial met
 tag:
 - how it works
 - production
-- non-energy minerals
+- nonenergy minerals
 - gold
 - copper
 - iron

--- a/_how-it-works/the-process/minerals.html
+++ b/_how-it-works/the-process/minerals.html
@@ -3,11 +3,11 @@ title: Nonenergy Minerals | How it Works
 layout: default
 description: The General Mining Act of 1872 regulates gold, silver, cinnabar, copper, and “other valuable deposits.” Despite some amendments, this legislation still governs extraction of many nonenergy minerals, in particular hardrock locatable minerals on federal public domain lands.
 tag:
-- How it works
-- Non-energy
-- Minerals
-- Process
-- Resources
+- how it works
+- nonenergy
+- minerals
+- process
+- resources
 permalink: /how-it-works/minerals/
 ---
 

--- a/_how-it-works/tribal-production.md
+++ b/_how-it-works/tribal-production.md
@@ -11,8 +11,8 @@ nav_items:
     subnav_items:
       - name: oil-and-gas
         title: Oil and gas
-      - name: non-energy-minerals
-        title: Non-energy minerals
+      - name: nonenergy-minerals
+        title: Nonenergy minerals
       - name: coal
         title: Coal
   - name: renewable-energy
@@ -43,7 +43,7 @@ This overview is based on the [Onshore Energy and Mineral Lease Management Inter
 
 ## Leasing process for mineral resources
 
-A number of agencies within the Department of the Interior play a role in the process of developing oil, gas, coal, or non-energy minerals on tribal land:
+A number of agencies within the Department of the Interior play a role in the process of developing oil, gas, coal, or nonenergy minerals on tribal land:
 
 - The [Bureau of Indian Affairs](https://www.bia.gov/) (BIA)
 - The [Bureau of Land Management](https://www.blm.gov/) (BLM)
@@ -102,7 +102,7 @@ A mineral trust owner may wish to assume the operation or ownership of a well. I
 
 <!-- content still needs de-duplicating -->
 
-### Non-energy minerals
+### Nonenergy minerals
 
 #### Plan
 

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -53,7 +53,7 @@ state_impact: |
 
 The state of Montana regulates extraction and interacts with extractive industry companies in Montana, particularly when they're operating on state or private land.
 
-The [Montana Department of Revenue](https://revenue.mt.gov/) collects, manages, and distributes  revenue from companies engaged in extraction of oil, natural gas, coal, and non-energy minerals in Montana. It publishes [biennial reports](https://revenue.mt.gov/home/publications/biennial_reports) and other [tax related reports](https://revenue.mt.gov/home/publications). County governments also collect many property taxes.
+The [Montana Department of Revenue](https://revenue.mt.gov/) collects, manages, and distributes  revenue from companies engaged in extraction of oil, natural gas, coal, and nonenergy minerals in Montana. It publishes [biennial reports](https://revenue.mt.gov/home/publications/biennial_reports) and other [tax related reports](https://revenue.mt.gov/home/publications). County governments also collect many property taxes.
 
 The [Montana Department of Natural Resources and Conservation](http://dnrc.mt.gov/) manages Montana's natural resources, including administering state trust lands and distributing revenue from state trust lands.
 


### PR DESCRIPTION
Fixes #3023

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/tag-audit/)

Changes proposed in this pull request:

- Minor tag update for consistency ("non-energy" to "nonenergy") - _reference [content guide](https://github.com/ONRR/doi-extractives-data/wiki/Content-guide) for format_
- Updates redirect for Federal revenue by company (links currently go to 2015 data instead of 2016)
- Updates current year in `years.yml` file
