### PR TITLE
Updates (another) redirect for company data, adds waters to description

### DIFF
--- a/_explore/revenue/federal-revenue-by-company/index.html
+++ b/_explore/revenue/federal-revenue-by-company/index.html
@@ -1,5 +1,5 @@
 ---
 layout: redirect
 permalink: /explore/federal-revenue-by-company/
-redirect_url: /explore/federal-revenue-by-company/2015/
+redirect_url: /explore/federal-revenue-by-company/2016/
 ---

--- a/_layouts/federal-revenue-by-company.html
+++ b/_layouts/federal-revenue-by-company.html
@@ -66,7 +66,7 @@ title_display: Federal Revenue by Company
           <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
           from
           <span href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</span>
-          extraction on federal lands ({{ page.report_year }})
+          extraction on federal lands and waters ({{ page.report_year }})
         </h1>
 
         <div class="container">


### PR DESCRIPTION
Fixes #3075

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/and-waters/how-it-works/federal-revenue-by-company)

Changes proposed in this pull request:

- Updates another redirect for federal revenue by company (I'm not even sure this one does anything)
- Adds "waters" to description for clarity
