### PR TITLE
Adds waters to second instance of descriptive text

### DIFF
--- a/_layouts/federal-revenue-by-company.html
+++ b/_layouts/federal-revenue-by-company.html
@@ -82,7 +82,7 @@ title_display: Federal Revenue by Company
           <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
           from
           <span href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</span>
-          extraction on federal lands ({{ page.report_year }})
+          extraction on federal lands and waters ({{ page.report_year }})
         </h1>
       </div>
 


### PR DESCRIPTION

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/and-waters/how-it-works/federal-revenue-by-company/2016/)

Changes proposed in this pull request:

- The text on mobile wasn't updating, so this updates the content that drives the mobile version of the text
