### PR TITLE
Adds smooth scrolling for in-page links

### DIFF
--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -22,6 +22,7 @@ time, mark, audio, video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
+  scroll-behavior: smooth;
 }
 
 /* HTML5 display-role reset for older browsers */


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/smooth-scroll/explore/)

Linking to different sections in the same page can disorient users who may think they have linked to a separate page. One of the ways to combat this is by automatically scrolling to the relevant section to expose to users where they are going relative to where they are at. 

**However**, we should weigh this navigational benefit against some potential negative outcomes of animation for users with [vestibular disorders](https://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity). There are benefits _and_ drawbacks we should assess as a team. Thankfully, this is a trivial behavior to add or remove.

Also note, this behavior won't work on IE 11, Safari, and some other browsers. That isn't a big deal, since those browsers will simply ignore the CSS rule and behave the way the site currently does.

To see this behavior, use the preview link and click the nav menu on the right.

Changes proposed in this pull request:

- Adds `scroll-behavior: smooth` to CSS reset
