### PR TITLE
How the LWCF and HPF work

### DIFF
--- a/_data/terms.yml
+++ b/_data/terms.yml
@@ -4,6 +4,7 @@
  "Acquisition fee": "A fee for securing an uncompetitive lease in place of a bonus."
  "Annual fee": "A yearly maintenance fee for maintaining a claim."
  "APD": "Application for permit to drill"
+ "Authorization": "An act of Congress to obligate funding for a program or agency. An authorization may be effective for one year, a fixed number of years, or an indefinite period. An authorization may be for a definite amount of money or for 'such sums as may be necessary.' The formal federal spending process consists of two sequential steps: authorization and then appropriation."
  "Barrel": "In the U.S., an oil barrel is defined as 42 US gallons, and abbreviated as bbl."
  "bbl": "Abbreviation for a unit of measurement of oil. One bbl, or oil barrel, is defined as 42 US gallons."
  "Biomass": "Organic nonfossil matter used as fuel. Sources of biomass include wood, wood waste products, biofuel, and many plant-based materials."

--- a/_downloads/disbursements.md
+++ b/_downloads/disbursements.md
@@ -93,7 +93,7 @@ In the past, this site has offered detailed data for disbursements distributed f
 
 ### Land and Water Conservation Fund
 
-{{ "ONRR" | term }} disburses revenue to the [Land and Water Conservation Fund (LWCF)](https://www.nps.gov/subjects/lwcf/index.htm) according to federal law. However, these funds are subject to congressional appropriations. Some of the money disbursed from ONRR to the fund is spent on LWCF projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $900 million each year, but congressional appropriations to LWCF projects have been limited to between $149 million and $573 million each year since 1999.
+{{ "ONRR" | term }} disburses revenue to the [Land and Water Conservation Fund (LWCF)](https://www.nps.gov/subjects/lwcf/index.htm) according to federal law. However, these funds are subject to congressional appropriations. Actual annual appropriations to the fund have met the authorized threshold only twice (1998, 2001), while appropriations have been limited to between $255 million and $450 million since 2008.
 
 To see how much was disbursed to states, sub-funds, and other projects each year, see the following datasets.
 

--- a/_how-it-works/aml-fees.md
+++ b/_how-it-works/aml-fees.md
@@ -1,5 +1,5 @@
 ---
-title: 'AML Reclamation Program | How it Works'
+title: 'AML Reclamation Program | How It Works'
 title_display: Abandoned Mine Land Reclamation Program
 layout: content
 description: The Abandoned Mine Land (AML) Reclamation Program uses fees paid by present-day coal mining companies to reclaim coal mines abandoned before 1977. This makes these areas safer for people and the environment. The Surface Mining Control and Reclamation Act (SMCRA) of 1977 created this program. The program sets standards for today's coal companies as they reclaim past mining areas while they mine others and to post bonds to cover the cost if unable to reclaim current coal mines.

--- a/_how-it-works/audits-and-assurances.md
+++ b/_how-it-works/audits-and-assurances.md
@@ -1,5 +1,5 @@
 ---
-title: 'Audits and Assurances | How it Works'
+title: 'Audits and Assurances | How It Works'
 title_display: Revenue data standards, audits, and assurances
 layout: content
 description: Data about revenue from the extractive industries is subject to a number of controls, standards, and regulations in the United States. Companies and governments are accountable to internal and external oversight that ensures correct reporting and publication of payments.

--- a/_how-it-works/coal-excise-tax.md
+++ b/_how-it-works/coal-excise-tax.md
@@ -1,5 +1,5 @@
 ---
-title: 'Coal excise tax | How it Works'
+title: 'Coal excise tax | How It Works'
 title_display: Coal excise tax
 layout: content
 description: In the United States, one of the taxes coal producers must pay is a federal excise tax when they mine coal. Producers pay the tax when the coal is first sold or used. The tax does not apply to lignite or to coal mined in the U.S. for export.

--- a/_how-it-works/default.md
+++ b/_how-it-works/default.md
@@ -1,5 +1,5 @@
 ---
-title: How it works
+title: How It Works
 layout: default
 permalink: /how-it-works/
 redirect_from: /how-it-works/production/

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -34,7 +34,7 @@ In the act, Congress declared, "the preservation of this irreplaceable heritage 
 ## Authorization and funding
 The Historic Preservation Fund is {{ "authorized" | term: "authorization" }} to receive $150 million each year through fiscal year 2023. Like the [Land and Water Conservation Fund]({{site.baseurl}}/how-it-works/land-and-water-conservation-fund), the HPF is subject to congressional appropriations during the annual budget process. Actual appropriations to the HPF have varied of the years, ranging from $54 million to $100 million between 2009 to 2017. Congress can choose to appropriate supplemental funding in the event of natural disasters – such as hurricanes – as they did in 2013 and 2018. 
 
-[Review the National Park Service annual budget justifications (the "Green Book")](https://www.nps.gov/aboutus/budget.htm) 
+The National Park Service publishes [annual budget justifications](https://www.nps.gov/aboutus/budget.htm) (the "Green Book") that detail appropriations and spending.
 
 ## Distribution of funds
 The National Parks Service apportions HPF grants according to a formula specified in the National Historic Preservation Act. The formula establishes three tiers that determine the funding allocation based on the annual appropriated amount. 

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -34,6 +34,8 @@ In the act, Congress declared, "the preservation of this irreplaceable heritage 
 ## Authorization and funding
 The Historic Preservation Fund is {{ "authorized" | term: "authorization" }} to receive $150 million each year through fiscal year 2023. Like the [Land and Water Conservation Fund]({{site.baseurl}}/how-it-works/land-and-water-conservation-fund), the HPF is subject to congressional appropriations during the annual budget process. Actual appropriations to the HPF have varied of the years, ranging from $54 million to $100 million between 2009 to 2017. Congress can choose to appropriate supplemental funding in the event of natural disasters – such as hurricanes – as they did in 2013 and 2018. 
 
+[Review the National Park Service annual budget justifications (the "Green Book")](https://www.nps.gov/aboutus/budget.htm) 
+
 ## Distribution of funds
 The National Parks Service apportions HPF grants according to a formula specified in the National Historic Preservation Act. The formula establishes three tiers that determine the funding allocation based on the annual appropriated amount. 
 

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -15,13 +15,9 @@ breadcrumb:
   - title: How it works
     permalink: /how-it-works/
 title_display: Historic Preservation Fund
-selector: list
 ---
 
 > {{ page.description }}
-
-{% include selector.html %}
-
 
 ## Funding priorities
 

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -32,7 +32,7 @@ The fund provides grants to state and tribal historic preservation offices to su
 In the act, Congress declared, "the preservation of this irreplaceable heritage is in the public interest so that its vital legacy of cultural, educational, aesthetic, inspirational, economic, and energy benefits will be maintained and enriched for future generations of Americans."
 
 ## Authorization and funding
-The Historic Preservation Fund is {{ "authorized" | term: "authorization" }} to receive $150 million each year through fiscal year 2023. Like the [Land and Water Conservation Fund]({{site.baseurl}}/how-it-works/land-and-water-conservation-fund), the HPF is subject to congressional appropriations during the annual budget process. Actual appropriations to the HPF have varied of the years, ranging from $54 million to $100 million between 2009 to 2017. Congress can choose to appropriate supplemental funding in the event of natural disasters – such as hurricanes – as they did in 2013 and 2018. 
+The Historic Preservation Fund is {{ "authorized" | term: "authorization" }} to receive $150 million each year through fiscal year 2023. Like the [Land and Water Conservation Fund]({{site.baseurl}}/how-it-works/land-and-water-conservation-fund), the HPF is subject to congressional appropriations during the annual budget process. Actual appropriations to the HPF have varied of the years, ranging from $54 million to $100 million between 2009 and 2017. Congress can choose to appropriate supplemental funding in the event of natural disasters – such as hurricanes – as they did in 2013 and 2018. 
 
 The National Park Service publishes [annual budget justifications](https://www.nps.gov/aboutus/budget.htm) (the "Green Book") that detail appropriations and spending.
 

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -22,7 +22,7 @@ title_display: Historic Preservation Fund
 Congress created the fund with the passage of the National Historic Preservation Act of 1966 and began funding it in 1976. The National Parks Service administers the HPF. 
 
 ## Funding priorities
-The fund provides grants to state and tribal historic preservation offices to support the conservation of cultural and historic sites. The fund supports the goals of the National Historic Preservation Act, which authorizes the Secretary of the Interior to:
+The fund provides grants to state and tribal historic preservation offices to support the conservation of cultural and historic sites. The fund aligns with the goals of the National Historic Preservation Act, which authorizes the Secretary of the Interior to:
 
 - maintain a National Register of Historic Places
 - issue regulations for State Historic Preservation Programs

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -1,0 +1,35 @@
+---
+title: Historic Preservation Fund | How It Works
+layout: content
+permalink: /how-it-works/historic-preservation-fund/
+description: The Historic Preservation Fund (HPF) provides matching grants to state and tribal historic preservation offices to pay for surveys, training, and grants. The HPF is funded by revenue from offshore oil and gas leases.
+tag:
+- how it works
+- offshore
+- conservation
+- Gulf of Mexico
+- disbursements
+- historic
+- grants
+breadcrumb:
+  - title: How it works
+    permalink: /how-it-works/
+title_display: Historic Preservation Fund
+selector: list
+---
+
+> {{ page.description }}
+
+{% include selector.html %}
+
+
+## Funding priorities
+
+
+## Authorization and funding
+
+
+## Distribution of funds
+
+
+### State and local grant funding

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -19,13 +19,31 @@ title_display: Historic Preservation Fund
 
 > {{ page.description }}
 
-## Funding priorities
+Congress created the fund with the passage of the [National Historic Preservation Act of 1966 (as amended)](http://uscode.house.gov/view.xhtml?req=granuleid%3AUSC-prelim-title54-subtitle3&saved=%7CKHRpdGxlOjU0IHNlY3Rpb246MzAwMTAxIGVkaXRpb246cHJlbGltKSBPUiAoZ3JhbnVsZWlkOlVTQy1wcmVsaW0tdGl0bGU1NC1zZWN0aW9uMzAwMTAxKQ%3D%3D%7CdHJlZXNvcnQ%3D%7C%7C0%7Cfalse%7Cprelim&edition=prelim). The National Parks Service administers the HPF. 
 
+## Funding priorities
+The fund provides grants to state and tribal historic preservation offices to support the conservation of cultural and historic sites. The fund supports the goals of the National Historic Preservation Act, which authorizes the Secretary of the Interior to:
+
+- maintain a National Register of Historic Places
+- issue regulations for State Historic Preservation Programs
+- award matching grants to states
+- award matching grants to the [National Trust for Historic Preservation](https://savingplaces.org/)
+
+In the act, Congress declared, "the preservation of this irreplaceable heritage is in the public interest so that its vital legacy of cultural, educational, aesthetic, inspirational, economic, and energy benefits will be maintained and enriched for future generations of Americans."
 
 ## Authorization and funding
-
+The Historic Preservation Fund is {{ "authorized" | term: "authorization" }} to receive $150 million each year through fiscal year 2023. Like the [Land and Water Conservation Fund]({{site.baseurl}}/how-it-works/land-and-water-conservation-fund), the HPF is subject to congressional appropriations during the annual budget process. Actual appropriations to the HPF have varied of the years, ranging from $54 million to $100 million between 2009 to 2017. Congress can choose to appropriate supplemental funding in the event of natural disasters – such as hurricanes – as they did in 2013 and 2018. 
 
 ## Distribution of funds
+The National Parks Service apportions HPF grants according to a formula specified in the National Historic Preservation Act. The formula establishes three tiers that determine the funding allocation based on the annual appropriated amount. 
 
+### Requirements
 
-### State and local grant funding
+Eligible grant applicants must be:
+
+- states operating approved State Historic Preservation Programs
+- Indian tribes and Native Hawaiian organizations
+- National Trust for Historic Preservation
+- certified local governments where there is no approved state program
+
+Review the [Historic Preservation Fund grants manual](https://www.nps.gov/preservation-grants/HPF_Manual.pdf), published by the National Park Service.

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -46,4 +46,4 @@ Eligible grant applicants must be one of the following:
 - National Trust for Historic Preservation
 - certified local governments where there is no approved state program
 
-Review the [Historic Preservation Fund grants manual](https://www.nps.gov/preservation-grants/HPF_Manual.pdf), published by the National Park Service.
+Review the National Park Service's [Historic Preservation Fund grants manual](https://www.nps.gov/preservation-grants/HPF_Manual.pdf) for more guidance on the grant application and approval process.

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -32,7 +32,7 @@ The fund provides grants to state and tribal historic preservation offices to su
 In the act, Congress declared, "the preservation of this irreplaceable heritage is in the public interest so that its vital legacy of cultural, educational, aesthetic, inspirational, economic, and energy benefits will be maintained and enriched for future generations of Americans."
 
 ## Authorization and funding
-The Historic Preservation Fund is {{ "authorized" | term: "authorization" }} to receive $150 million each year through fiscal year 2023. Like the [Land and Water Conservation Fund]({{site.baseurl}}/how-it-works/land-and-water-conservation-fund), the HPF is subject to congressional appropriations during the annual budget process. Actual appropriations to the HPF have varied of the years, ranging from $54 million to $100 million between 2009 and 2017. Congress can choose to appropriate supplemental funding in the event of natural disasters – such as hurricanes – as they did in 2013 and 2018. 
+The Historic Preservation Fund is {{ "authorized" | term: "authorization" }} to receive $150 million each year through fiscal year 2023. Like the [Land and Water Conservation Fund]({{site.baseurl}}/how-it-works/land-and-water-conservation-fund), the HPF is subject to congressional appropriations during the annual budget process. Actual appropriations to the HPF have varied over the years, ranging from $54 million to $100 million between 2009 and 2017. Congress can choose to appropriate supplemental funding in the event of natural disasters – such as hurricanes – as they did in 2013 and 2018. 
 
 The National Park Service publishes [annual budget justifications](https://www.nps.gov/aboutus/budget.htm) (the "Green Book") that detail appropriations and spending.
 

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -39,7 +39,7 @@ The National Parks Service apportions HPF grants according to a formula specifie
 
 ### Requirements
 
-Eligible grant applicants must be:
+Eligible grant applicants must be one of the following:
 
 - states operating approved State Historic Preservation Programs
 - Indian tribes and Native Hawaiian organizations

--- a/_how-it-works/hpf.md
+++ b/_how-it-works/hpf.md
@@ -19,7 +19,7 @@ title_display: Historic Preservation Fund
 
 > {{ page.description }}
 
-Congress created the fund with the passage of the [National Historic Preservation Act of 1966 (as amended)](http://uscode.house.gov/view.xhtml?req=granuleid%3AUSC-prelim-title54-subtitle3&saved=%7CKHRpdGxlOjU0IHNlY3Rpb246MzAwMTAxIGVkaXRpb246cHJlbGltKSBPUiAoZ3JhbnVsZWlkOlVTQy1wcmVsaW0tdGl0bGU1NC1zZWN0aW9uMzAwMTAxKQ%3D%3D%7CdHJlZXNvcnQ%3D%7C%7C0%7Cfalse%7Cprelim&edition=prelim). The National Parks Service administers the HPF. 
+Congress created the fund with the passage of the National Historic Preservation Act of 1966 and began funding it in 1976. The National Parks Service administers the HPF. 
 
 ## Funding priorities
 The fund provides grants to state and tribal historic preservation offices to support the conservation of cultural and historic sites. The fund supports the goals of the National Historic Preservation Act, which authorizes the Secretary of the Interior to:

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -11,6 +11,7 @@ tag:
 - GOMESA
 - disbursements
 - recreation
+- grants
 - National Park Service
 breadcrumb:
   - title: How it works

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -46,7 +46,11 @@ Most of the funds from the LWCF are distributed to support two general purposes:
 - federal acquisition of land for the benefit of the public
 - grants to states for recreational planning, acquiring recreational lands, or developing outdoor recreational facilities 
 
-A portion of funds also supports the [American Battlefield Protection Program](https://www.nps.gov/abpp/grants/grants.htm), sponsoring the preservation of historic battlefields. 
+A portion of funds also supports:
+
+- [American Battlefield Protection Program](https://www.nps.gov/abpp/grants/grants.htm), sponsoring the preservation of historic battlefields
+- [Forest Legacy Program](https://www.fs.fed.us/managing-land/private-land/forest-legacy), a Forest Service program to encourage the protection of privately owned forest lands
+- [Cooperative Endangered Species Conservation Fund](https://www.fws.gov/endangered/grants/), a Fish and Wildlife Service program that provides funding to states and territories for species and habitat conservation on non-federal lands
 
 Every year during the budget process, Congress determines the total appropriation from the fund to support each of these purposes.
 
@@ -61,6 +65,8 @@ During the annual budget process, these agencies can submit proposals to acquire
 Administered by the National Park Service, the stateside program of the LWCF provides matching grants to states for planning, acquiring lands and waters, and developing facilities for outdoor recreation. LWCF funds are limited to 50% or less of a proposed project's total cost; the rest must come from other funds.
 
 A formula in the Land and Water Conservation Act determines how the funds are apportioned to states (See [54 U.S.C. §200305(b)](https://www.gpo.gov/fdsys/granule/USCODE-2014-title54/USCODE-2014-title54-subtitleII-chap2003-sec200305)). States must use the money for its intended purpose within three years.
+
+[Review state and local grant funding](https://www.nps.gov/subjects/lwcf/statefundingstatus.htm).
 
 #### GOMESA grants
 The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million in funding. This portion of LWCF funds is not subject to congressional appropriation, and states can roll it over beyond the three-year limit of other LWCF state grants. 

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -39,20 +39,22 @@ The LWCF is authorized through September 30, 2018, at which time Congress must d
 
 The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue. {{ "ONRR" | term }} disburses that revenue to the fund each year.
 
-The LWCF is authorized to receive and distribute $900 million each year, but the fund is subject to congressional budget appropriations. Actual annual appropriations to the fund have met the authorized threshold only once (2001), while appropriations have been limited to between $255 million and $450 million since 2008.
+The LWCF is authorized to receive and distribute $900 million each year, but the fund is subject to congressional budget appropriations. Actual annual appropriations to the fund have met the authorized threshold only twice (1998, 2001), while appropriations have been limited to between $255 million and $450 million since 2008.
 
 ## Distribution of funds
-Funds from the LWCF are distributed to support two general purposes:
+Most of the funds from the LWCF are distributed to support two general purposes:
 
-- [federal acquisition of land](https://www.nps.gov/subjects/lwcf/federalside.htm) for the benefit of the public
+- federal acquisition of land for the benefit of the public
 - grants to states for recreational planning, acquiring recreational lands, or developing outdoor recreational facilities 
+
+A portion of funds also supports the [American Battlefield Protection Program](https://www.nps.gov/abpp/grants/grants.htm), sponsoring the preservation of historic battlefields. 
 
 Every year during the budget process, Congress determines the total appropriation from the fund to support each of these purposes.
 
 ### Federal land acquisition
 Federal land management agencies include the Forest Service, National Park Service, Fish and Wildlife Service, and the Bureau of Land Management.
 
-During the annual budget process, these agencies can submit proposals to acquire lands or waters with LWCF funds. LWCF funds for land acquistion can be carried over from fiscal year to fiscal year until expended.
+During the annual budget process, these agencies can submit proposals to acquire lands or waters with LWCF funds. LWCF funds for land acquisition can be carried over from fiscal year to fiscal year until expended.
 
 [Review LWCF Land Acquisition Reports and Data](https://www.nps.gov/subjects/lwcf/land-acquisition-reports-and-data.htm)
 

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -21,8 +21,6 @@ title_display: Land and Water Conservation Fund
 
 > {{ page.description }}
 
-{% include selector.html %}
-
 The [Land and Water Conservation Fund](https://www.nps.gov/subjects/lwcf/index.htm) provides competitive grants to states for local preservation and recreation projects, along with a federal portion to acquire lands and waters for public recreation or cultural preservation.
 
 ## Funding priorities

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -7,7 +7,8 @@ tag:
 - how it works
 - offshore
 - conservation
-- gulf of mexico
+- Gulf of Mexico
+- GOMESA
 - disbursements
 - recreation
 - National Park Service
@@ -61,7 +62,7 @@ During the annual budget process, these agencies can submit proposals to acquire
 ### State and local grant funding
 Administered by the National Park Service, the stateside program of the LWCF provides matching grants to states for planning, acquiring lands and waters, and developing facilities for outdoor recreation. LWCF funds are limited to 50% or less of a proposed project's total cost; the rest must come from other funds.
 
-A formula in the Land and Water Conservation Act determines how the funds are apportioned to states [(54 U.S.C. §200305(b))](https://www.gpo.gov/fdsys/granule/USCODE-2014-title54/USCODE-2014-title54-subtitleII-chap2003-sec200305). States must use the money for its intended purpose within three years.
+A formula in the Land and Water Conservation Act determines how the funds are apportioned to states (See [54 U.S.C. §200305(b))](https://www.gpo.gov/fdsys/granule/USCODE-2014-title54/USCODE-2014-title54-subtitleII-chap2003-sec200305). States must use the money for its intended purpose within three years.
 
 #### GOMESA grants
 The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million in funding. This portion of LWCF funds is not subject to congressional appropriation, and states can roll it over beyond the three-year limit of other LWCF state grants. 

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -36,7 +36,7 @@ The LWCF funds landscape conservation, outdoor recreation, and the needs of loca
 - wildlife habitat
 
 ## Authorization and funding
-The LWCF is authorized through September 30, 2018, at which time Congress must decide whether to reauthorize the program.
+The LWCF is {{ "authorized" | term: "authorization" }} through September 30, 2018, at which time Congress must decide whether to reauthorize the program.
 
 The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue. {{ "ONRR" | term }} disburses that revenue to the fund each year.
 

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -55,7 +55,7 @@ Federal land management agencies include the Forest Service, National Park Servi
 
 During the annual budget process, these agencies can submit proposals to acquire lands or waters with LWCF funds. LWCF funds for land acquisition can be carried over from fiscal year to fiscal year until expended.
 
-[Review LWCF Land Acquisition Reports and Data](https://www.nps.gov/subjects/lwcf/land-acquisition-reports-and-data.htm)
+[Review LWCF Land Acquisition Reports and Data](https://www.nps.gov/subjects/lwcf/land-acquisition-reports-and-data.htm).
 
 ### State and local grant funding
 Administered by the National Park Service, the stateside program of the LWCF provides matching grants to states for planning, acquiring lands and waters, and developing facilities for outdoor recreation. LWCF funds are limited to 50% or less of a proposed project's total cost; the rest must come from other funds.
@@ -65,4 +65,4 @@ A formula in the Land and Water Conservation Act determines how the funds are ap
 #### GOMESA grants
 The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million in funding. This portion of LWCF funds is not subject to congressional appropriation, and states can roll it over beyond the three-year limit of other LWCF state grants. 
 
-[Review LWCF State and Local Grant Funding](https://www.nps.gov/subjects/lwcf/stateside.htm)
+[Review LWCF State and Local Grant Funding](https://www.nps.gov/subjects/lwcf/stateside.htm).

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -1,0 +1,44 @@
+---
+title: Land and Water Conservation Fund | How It Works
+layout: content
+permalink: /how-it-works/land-and-water-conservation-fund/
+description: The Land and Water Conservation Fund (LWCF) was enacted in 1965. It supports preservation, development, and access to outdoor lands for public recreation. The LWCF is funded by revenue from offshore oil and gas leases. 
+tag:
+- how it works
+- offshore
+- conservation
+- gulf of mexico
+- disbursements
+- recreation
+- National Park Service
+breadcrumb:
+  - title: How it works
+    permalink: /how-it-works/
+title_display: Land and Water Conservation Fund
+selector: list
+---
+
+> {{ page.description }}
+
+{% include selector.html %}
+
+Administered by the [National Park Service](https://www.nps.gov/subjects/lwcf/index.htm), the LWCF provides competitive grants to states for local preservation and recreation projects, along with a federal portion to acquire lands and waters for public recreation or cultural preservation.
+
+## Funding priorities
+The LWCF funds landscape conservation, outdoor recreation, and the needs of local communities, including:
+
+- access to outdoors
+- national trails
+- working lands (e.g. private working farms, forests, and ranches)
+- historic or cultural sites
+- urban parks
+- wildlife habitat
+
+## Authorization and funding
+The LWCF is authorized through September 30, 2018, at which time Congress must decide whether to reauthorize the program.
+
+The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue.{{ "ONRR" | term }} disburses that revenue to the fund each year.
+
+The LWCF is authorized to receive and distribute $900 million each year, but the fund is subject to congressional budget appropriations. Actual annual appropriations to the fund have met the authorized threshold only once (2001), while appropriations have been limited to between $255 million and $450 million since 2008.
+
+## Distribution of funds

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -22,7 +22,7 @@ selector: list
 
 {% include selector.html %}
 
-Administered by the [National Park Service](https://www.nps.gov/subjects/lwcf/index.htm), the LWCF provides competitive grants to states for local preservation and recreation projects, along with a federal portion to acquire lands and waters for public recreation or cultural preservation.
+Administered by the National Park Service, the [Land and Water Conservation Fund](https://www.nps.gov/subjects/lwcf/index.htm) provides competitive grants to states for local preservation and recreation projects, along with a federal portion to acquire lands and waters for public recreation or cultural preservation.
 
 ## Funding priorities
 The LWCF funds landscape conservation, outdoor recreation, and the needs of local communities, including:

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -55,7 +55,7 @@ Federal land management agencies include the Forest Service, National Park Servi
 
 During the annual budget process, these agencies can submit proposals to acquire lands or waters with LWCF funds. LWCF funds for land acquisition can be carried over from fiscal year to fiscal year until expended.
 
-[Review LWCF Land Acquisition Reports and Data](https://www.nps.gov/subjects/lwcf/land-acquisition-reports-and-data.htm).
+[Review land acquisition reports and data](https://www.nps.gov/subjects/lwcf/land-acquisition-reports-and-data.htm).
 
 ### State and local grant funding
 Administered by the National Park Service, the stateside program of the LWCF provides matching grants to states for planning, acquiring lands and waters, and developing facilities for outdoor recreation. LWCF funds are limited to 50% or less of a proposed project's total cost; the rest must come from other funds.
@@ -65,4 +65,4 @@ A formula in the Land and Water Conservation Act determines how the funds are ap
 #### GOMESA grants
 The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million in funding. This portion of LWCF funds is not subject to congressional appropriation, and states can roll it over beyond the three-year limit of other LWCF state grants. 
 
-[Review LWCF State and Local Grant Funding](https://www.nps.gov/subjects/lwcf/stateside.htm).
+[Review state and local grant funding](https://www.nps.gov/subjects/lwcf/stateside.htm).

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -17,7 +17,6 @@ breadcrumb:
   - title: How it works
     permalink: /how-it-works/
 title_display: Land and Water Conservation Fund
-selector: list
 ---
 
 > {{ page.description }}

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -22,7 +22,7 @@ selector: list
 
 {% include selector.html %}
 
-Administered by the National Park Service, the [Land and Water Conservation Fund](https://www.nps.gov/subjects/lwcf/index.htm) provides competitive grants to states for local preservation and recreation projects, along with a federal portion to acquire lands and waters for public recreation or cultural preservation.
+The [Land and Water Conservation Fund](https://www.nps.gov/subjects/lwcf/index.htm) provides competitive grants to states for local preservation and recreation projects, along with a federal portion to acquire lands and waters for public recreation or cultural preservation.
 
 ## Funding priorities
 The LWCF funds landscape conservation, outdoor recreation, and the needs of local communities, including:
@@ -37,8 +37,31 @@ The LWCF funds landscape conservation, outdoor recreation, and the needs of loca
 ## Authorization and funding
 The LWCF is authorized through September 30, 2018, at which time Congress must decide whether to reauthorize the program.
 
-The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue.{{ "ONRR" | term }} disburses that revenue to the fund each year.
+The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue. {{ "ONRR" | term }} disburses that revenue to the fund each year.
 
 The LWCF is authorized to receive and distribute $900 million each year, but the fund is subject to congressional budget appropriations. Actual annual appropriations to the fund have met the authorized threshold only once (2001), while appropriations have been limited to between $255 million and $450 million since 2008.
 
 ## Distribution of funds
+Funds from the LWCF are distributed to support two general purposes:
+
+- [federal acquisition of land](https://www.nps.gov/subjects/lwcf/federalside.htm) for the benefit of the public
+- grants to states for recreational planning, acquiring recreational lands, or developing outdoor recreational facilities 
+
+Every year during the budget process, Congress determines the total appropriation from the fund to support each of these purposes.
+
+### Federal land acquisition
+Federal land management agencies include the Forest Service, National Park Service, Fish and Wildlife Service, and the Bureau of Land Management.
+
+During the annual budget process, these agencies can submit proposals to acquire lands or waters with LWCF funds. LWCF funds for land acquistion can be carried over from fiscal year to fiscal year until expended.
+
+[Review LWCF Land Acquisition Reports and Data](https://www.nps.gov/subjects/lwcf/land-acquisition-reports-and-data.htm)
+
+### State and local grant funding
+Administered by the National Park Service, the stateside program of the LWCF provides matching grants to states for planning, acquiring lands and waters, and developing facilities for outdoor recreation. LWCF funds are limited to 50% or less of a proposed project's total cost; the rest must come from other funds.
+
+A formula in the Land and Water Conservation Act determines how the funds are apportioned to states [(54 U.S.C. §200305(b))](https://www.gpo.gov/fdsys/granule/USCODE-2014-title54/USCODE-2014-title54-subtitleII-chap2003-sec200305). States must use the money for its intended purpose within three years.
+
+#### GOMESA grants
+The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million in funding. This portion of LWCF funds is not subject to congressional appropriation, and states can roll it over beyond the three-year limit of other LWCF state grants. 
+
+[Review LWCF State and Local Grant Funding](https://www.nps.gov/subjects/lwcf/stateside.htm)

--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -60,7 +60,7 @@ During the annual budget process, these agencies can submit proposals to acquire
 ### State and local grant funding
 Administered by the National Park Service, the stateside program of the LWCF provides matching grants to states for planning, acquiring lands and waters, and developing facilities for outdoor recreation. LWCF funds are limited to 50% or less of a proposed project's total cost; the rest must come from other funds.
 
-A formula in the Land and Water Conservation Act determines how the funds are apportioned to states (See [54 U.S.C. §200305(b))](https://www.gpo.gov/fdsys/granule/USCODE-2014-title54/USCODE-2014-title54-subtitleII-chap2003-sec200305). States must use the money for its intended purpose within three years.
+A formula in the Land and Water Conservation Act determines how the funds are apportioned to states (See [54 U.S.C. §200305(b)](https://www.gpo.gov/fdsys/granule/USCODE-2014-title54/USCODE-2014-title54-subtitleII-chap2003-sec200305)). States must use the money for its intended purpose within three years.
 
 #### GOMESA grants
 The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million in funding. This portion of LWCF funds is not subject to congressional appropriation, and states can roll it over beyond the three-year limit of other LWCF state grants. 

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -30,7 +30,7 @@
 
   <h4 id="lwcf">Land and Water Conservation Fund</h4>
 
-  <p>{{ "ONRR" | term }} disburses revenue to the <a href="https://www.nps.gov/subjects/lwcf/index.htm">Land and Water Conservation Fund</a> (LWCF) according to federal law. However, these funds are subject to congressional appropriations. Some of the money disbursed from ONRR to the fund is spent on LWCF projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $900 million each year, but congressional appropriations to LWCF projects have been limited to between $149 million and $573 million each year since 1999.</p>
+  <p>{{ "ONRR" | term }} disburses revenue to the <a href="https://www.nps.gov/subjects/lwcf/index.htm">Land and Water Conservation Fund</a> (LWCF) according to federal law. However, these funds are subject to congressional appropriations. Actual annual appropriations to the fund have met the authorized threshold only twice (1998, 2001), while appropriations have been limited to between $255 million and $450 million since 2008.</p>
 
   <p>
     <a href="{{site.baseurl}}/downloads/disbursements/#land-and-water-conservation-fund" class="data-downloads">


### PR DESCRIPTION
Fixes #3054

[:evergreen_tree: Land and Water Conservation Fund PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/how-funds-work/how-it-works/land-and-water-conservation-fund)

[:school: Historic Preservation Fund PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/how-funds-work/how-it-works/historic-preservation-fund)

Changes proposed in this pull request:

- Adds contextual content for the Land and Water Conservation Fund and Historic Preservation Fund (elsewhere we are adding actual annual congressional appropriations alongside the disbursed amount)
- Also adds two new terms to the glossary in this PR and in the [Gatsby explore data PR](https://github.com/ONRR/doi-extractives-data/pull/3106/commits/1b5c9b797481b43d13c290d83765e7f8793b4edb)
  - "8(g)"
  - "Authorization"
- Corrects existing summary content of congressional appropriations to the LWCF since 1999

Most content on the web for these funds is either too broad for our scope or too narrow. We needed an overview focused on the funding and appropriations process for these funds, which is why I researched and wrote this content.