### PR TITLE
Corrects rights-of-way in revenue scope

### DIFF
--- a/_downloads/federal-revenue-by-company.md
+++ b/_downloads/federal-revenue-by-company.md
@@ -77,7 +77,7 @@ Companies can adjust and correct their payments for up to seven years after a tr
 
 ### Why is the calendar year _revenue by location national total_ slightly different than the _revenue by company total_?
 
-Our site has two federal revenue datasets. The one on this page is organized by the company that paid the revenue. The [federal revenue by location dataset]({{ site.baseurl }}/downloads/federal-revenue-by-location/) is organized by location. However, the national revenue totals are slightly different (by about $90 million). This is because the revenue by location dataset excludes revenue from offshore right-of-ways because they don't map to an offshore planning area.
+Our site has two federal revenue datasets. The one on this page is organized by the company that paid the revenue. The [federal revenue by location dataset]({{ site.baseurl }}/downloads/federal-revenue-by-location/) is organized by location. However, the national revenue totals are slightly different (by about $90 million). This is because the revenue by location dataset excludes revenue from offshore rights-of-way because they don't map to an offshore planning area.
 
 ## Data dictionary
 

--- a/_downloads/federal-revenue-by-company.md
+++ b/_downloads/federal-revenue-by-company.md
@@ -77,7 +77,7 @@ Companies can adjust and correct their payments for up to seven years after a tr
 
 ### Why is the calendar year _revenue by location national total_ slightly different than the _revenue by company total_?
 
-Our site has two federal revenue datasets. The one on this page is organized by the company that paid the revenue. The [federal revenue by location dataset]({{ site.baseurl }}/downloads/federal-revenue-by-location/) is organized by location. However, the national revenue totals on these datasets are slightly different (by about $90 million). This is because the the company revenues dataset excludes revenue from offshore right-of-ways because they don't map to an offshore planning area.
+Our site has two federal revenue datasets. The one on this page is organized by the company that paid the revenue. The [federal revenue by location dataset]({{ site.baseurl }}/downloads/federal-revenue-by-location/) is organized by location. However, the national revenue totals are slightly different (by about $90 million). This is because the revenue by location dataset excludes revenue from offshore right-of-ways because they don't map to an offshore planning area.
 
 ## Data dictionary
 

--- a/_downloads/federal-revenue-by-location.md
+++ b/_downloads/federal-revenue-by-location.md
@@ -92,7 +92,7 @@ Companies can adjust and correct their payments for up to seven years after a tr
 
 ### Why is the calendar year _revenue by location national total_ slightly different than the _revenue by company total_?
 
-Our site has two federal revenue datasets. The one on this page is organized by location. [The federal revenue by company dataset]({{ site.baseurl }}/downloads/federal-revenue-by-company/) is organized by the company that paid the revenue. However, the national revenue totals are slightly different (by about $90 million). This is because the company revenues dataset excludes revenue from offshore right-of-ways because they don't map to an offshore planning area.
+Our site has two federal revenue datasets. The one on this page is organized by location. [The federal revenue by company dataset]({{ site.baseurl }}/downloads/federal-revenue-by-company/) is organized by the company that paid the revenue. However, the national revenue totals are slightly different (by about $90 million). This is because the revenue by location dataset excludes revenue from offshore right-of-ways because they don't map to an offshore planning area.
 
 ### Note: Geothermal rate details
 

--- a/_downloads/federal-revenue-by-location.md
+++ b/_downloads/federal-revenue-by-location.md
@@ -92,7 +92,7 @@ Companies can adjust and correct their payments for up to seven years after a tr
 
 ### Why is the calendar year _revenue by location national total_ slightly different than the _revenue by company total_?
 
-Our site has two federal revenue datasets. The one on this page is organized by location. [The federal revenue by company dataset]({{ site.baseurl }}/downloads/federal-revenue-by-company/) is organized by the company that paid the revenue. However, the national revenue totals are slightly different (by about $90 million). This is because the revenue by location dataset excludes revenue from offshore right-of-ways because they don't map to an offshore planning area.
+Our site has two federal revenue datasets. The one on this page is organized by location. [The federal revenue by company dataset]({{ site.baseurl }}/downloads/federal-revenue-by-company/) is organized by the company that paid the revenue. However, the national revenue totals are slightly different (by about $90 million). This is because the revenue by location dataset excludes revenue from offshore rights-of-way because they don't map to an offshore planning area.
 
 ### Note: Geothermal rate details
 


### PR DESCRIPTION
Fixes #3099

[:pig: PREVIEW - Federal revenue by company](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-scope/downloads/federal-revenue-by-company/#why-is-the-calendar-year-revenue-by-location-national-total-slightly-different-than-the-revenue-by-company-total)

[:pig: PREVIEW - Federal revenue by location](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-scope/downloads/federal-revenue-by-location/#why-is-the-calendar-year-revenue-by-location-national-total-slightly-different-than-the-revenue-by-company-total)

Changes proposed in this pull request:

- Corrects revenue scope content based on @jennmalcolm's guidance

- We should conduct a more thorough audit of this content (e.g. this content refers to $90 million difference: is that the same every year, or just for the year this content was written)
