### PR TITLE
Constrains data range to 10 years and fixes GPD year in dev

### DIFF
--- a/_data/years.yml
+++ b/_data/years.yml
@@ -1,17 +1,17 @@
 # XXX this must be a string to use it as an index into other data!
-now: 2018
+now: 2016
 
 default: [2007, 2016]
 
 exports: [2006, 2015]
 
-revenue: [2007, 2017]
+revenue: [2008, 2017]
 
 self_employment: [2007, 2016]
 
 disbursements: 2017
 
-all_production: [2007, 2017]
+all_production: [2008, 2017]
 
 federal_production: [2008, 2017]
 


### PR DESCRIPTION
Fixes #3129

[:pig: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/years/explore/WY)

Changes proposed in this pull request:

- Constrains `years` data file to 2008–2017 for `all-production` and `revenue`
  - We're currently charting 11 years for those two datasets
- Reverts `now` year from 2018 to 2016 to fix GDP data in `dev`
  - We fixed this in production, but we merged directly into `master`, so this PR fixes in `dev`
