### PR TITLE
Updates LWCF and HPF links to go to new pages

### DIFF
--- a/gatsby-site/src/data/fund_names.yml
+++ b/gatsby-site/src/data/fund_names.yml
@@ -12,13 +12,13 @@ Land & Water Conservation:
   description: Provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states. See below for more information about this fund.
   link: 
     name: How this fund works
-    to: /downloads/disbursements/#archive
+    to: /how-it-works/land-and-water-conservation-fund/
 Historic Preservation:
   name: Historic Preservation Fund
   description: Helps preserve U.S. historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices. See below for more information about this fund.
   link: 
     name: How this fund works
-    to: /downloads/disbursements/#archive
+    to: /how-it-works/historic-preservation-fund/
 American Indian Tribes:
   name: American Indian tribes and individuals
   description: ONRR disburses 100% of revenue collected from resource extraction on American Indian lands back to the Indian tribes and individual Indian landowners.


### PR DESCRIPTION
Fixes #3154

[:pig: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fund-links/explore/#federal-disbursements)

Changes proposed in this pull request:

- Updates "How this fund works" links in disbursements section for Land and Water Conservation Fund and Historic Preservation Fund to direct to new pages merged in #3133.
