### PR TITLE
Corrects punctuation around glossary term on about page

### DIFF
--- a/gatsby-site/src/pages/About/index.js
+++ b/gatsby-site/src/pages/About/index.js
@@ -115,7 +115,7 @@ const AboutPage = () => {
               </div>
               <div className="bureau-right">
                 <h4>Bureau of Safety and Environmental Enforcement (BSEE)</h4>
-                <p><a href="http://www.bsee.gov/">BSEE</a> is responsible for safety oversight of ocean energy development and production, including permitting and inspections, regulatory programs, and oil spill response. BSEE also updates rules governing operations on the <GlossaryTerm>Outer Continental Shelf.</GlossaryTerm></p>
+                <p><a href="http://www.bsee.gov/">BSEE</a> is responsible for safety oversight of ocean energy development and production, including permitting and inspections, regulatory programs, and oil spill response. BSEE also updates rules governing operations on the <GlossaryTerm>Outer Continental Shelf</GlossaryTerm>.</p>
               </div>
             </article>
 


### PR DESCRIPTION

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/about-punctuation/about)

Changes proposed in this pull request:

- Corrects punctuation placement in new version of `/about/` page

## New about page
![misplaced punctuation on about page](https://user-images.githubusercontent.com/32855580/44410517-690c9d80-a519-11e8-834a-b50712a0de6f.png)

## Production about page
![punctuation on production about page](https://user-images.githubusercontent.com/32855580/44410554-893c5c80-a519-11e8-856b-f60215a6ed93.png)
