### PR TITLE
Changes LWCF act year from 1965 to 1964 in description based on DOI references

### DIFF
--- a/_how-it-works/lwcf.md
+++ b/_how-it-works/lwcf.md
@@ -2,7 +2,7 @@
 title: Land and Water Conservation Fund | How It Works
 layout: content
 permalink: /how-it-works/land-and-water-conservation-fund/
-description: The Land and Water Conservation Fund (LWCF) was enacted in 1965. It supports preservation, development, and access to outdoor lands for public recreation. The LWCF is funded by revenue from offshore oil and gas leases. 
+description: The Land and Water Conservation Fund (LWCF) was enacted in 1964. It supports preservation, development, and access to outdoor lands for public recreation. The LWCF is funded by revenue from offshore oil and gas leases. 
 tag:
 - how it works
 - offshore


### PR DESCRIPTION
[:pig: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/act-year/how-it-works/land-and-water-conservation-fund/)

Changes proposed in this pull request:

Some references cite the passage of the act that created the Land and Water Conservation Fund as 1965, while others cite 1964. The appropriate year of codification appears to be subject to legal interpretation, explained in a footnote of one reference document (which cites the enacted year as 1965 in the main text) like so:

>  Act of September 3, 1964; P.L. 88-578, 78 Stat. 897. 54 U.S.C. §§200301 et seq. The text of the law had been codified at 16 U.S.C. §§460l-4 et seq. It was recodified under P.L. 113-287 to 54 U.S.C. §§200301 et seq. 

I originally wrote 1965, because that was the date I saw most often during research, but [DOI lists 1964](https://www.doi.gov/lwcf/about) on the LWCF about page. This change brings our content in line with DOI references elsewhere.
