### PR TITLE
Removes redundant copy in LWCF and HPF descriptions

### DIFF
--- a/gatsby-site/src/data/fund_names.yml
+++ b/gatsby-site/src/data/fund_names.yml
@@ -9,13 +9,13 @@ Reclamation:
   description: Supports the establishment of critical infrastructure projects like dams and power plants.
 Land & Water Conservation:
   name: Land and Water Conservation Fund
-  description: Provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states. See below for more information about this fund.
+  description: Provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states.
   link: 
     name: How this fund works
     to: /how-it-works/land-and-water-conservation-fund/
 Historic Preservation:
   name: Historic Preservation Fund
-  description: Helps preserve U.S. historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices. See below for more information about this fund.
+  description: Helps preserve U.S. historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices.
   link: 
     name: How this fund works
     to: /how-it-works/historic-preservation-fund/


### PR DESCRIPTION
[:bird: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fund-descriptions/explore/#federal-disbursements)

Changes proposed in this pull request:

- Removes redundant "See below..." copy from Land and Water Conservation Fund and Historic Preservation Fund descriptions. 
  - The descriptions are no longer necessary given the new pages and accompanying links
