### PR TITLE
Corrects year in description for 2016 federal revenue by company frontmatter

### DIFF
--- a/_federal-revenue-by-company/2016.md
+++ b/_federal-revenue-by-company/2016.md
@@ -1,7 +1,7 @@
 ---
 title: Federal Revenue By Company (2016) | Explore Data
 report_year: 2016
-description: Explore revenues on federal lands and waters in 2015 by commodity, revenue type, and company.
+description: Explore revenues on federal lands and waters in 2016 by commodity, revenue type, and company.
 tag:
 - How it works
 - Federal revenue


### PR DESCRIPTION
Metadata fix

Changes proposed in this pull request:

- Corrects year reference in front matter description for 2016 data
