### PR TITLE
Improves readability of company revenue data

### DIFF
--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -60,6 +60,10 @@
     text-align: left;
   }
 
+  .name td {
+    border-top: none;
+  }
+
   .bar_dollars {
     padding-right: $base-padding;
   }
@@ -144,7 +148,6 @@
     vertical-align: bottom;
   }
 
-
   .bar { // specific to reconcilation
     width: 100px;
 
@@ -194,6 +197,12 @@
   clear: both;
   padding: 0 $base-padding;
   position: relative;
+}
+
+tbody:not(:first-child):before {
+  content: '';
+  display: block;
+  height: 2rem;
 }
 
 .region-name,

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -140,6 +140,11 @@
     width: 3em;
   }
 
+  td, th .value.subtotal {
+    vertical-align: bottom;
+  }
+
+
   .bar { // specific to reconcilation
     width: 100px;
 


### PR DESCRIPTION
Fixes #3078

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/company-rev-style/how-it-works/federal-revenue-by-company/2016/)

Changes proposed in this pull request:

- Fixes alignment of company total; it is now aligned with the company name
- Adds white space between company tables to improve data recognition, association, and readability

## Production
![federal revenue by company table production](https://user-images.githubusercontent.com/32855580/45327524-b5da0780-b50c-11e8-9f54-9cb263299ac1.png)

## This branch
![federal revenue by company table this branch](https://user-images.githubusercontent.com/32855580/45327546-c7bbaa80-b50c-11e8-8e2c-9be268c013aa.png)
