### PR TITLE
Edits production subheadings, nav items based on user input

### DIFF
--- a/gatsby-site/src/components/locations/NationalAllProduction.js
+++ b/gatsby-site/src/components/locations/NationalAllProduction.js
@@ -25,7 +25,7 @@ const NationalAllProduction = (props) => {
 
     return (
         <section id="all-production" is="year-switcher-section" class="all-lands production">
-            <StickyHeader headerText='Energy production nationwide'>
+            <StickyHeader headerText='All lands and waters'>
                 <YearSelector years={[2017,2016,2015,2014,2013,2012,2011,2010,2009,2008]} classNames="flex-row-icon" />
             </StickyHeader>
 

--- a/gatsby-site/src/components/locations/NationalFederalProduction.js
+++ b/gatsby-site/src/components/locations/NationalFederalProduction.js
@@ -80,7 +80,7 @@ const NationalFederalProduction = (props) => {
         <section id="federal-production" is="year-switcher-section" className="federal production">
 
             <section className="county-map-table" is="year-switcher-section">
-                <StickyHeader headerText='Production on federal land nationwide'>
+                <StickyHeader headerText='Federal lands and waters'>
                     <YearSelector years={years} classNames="flex-row-icon" />
                 </StickyHeader>
 

--- a/gatsby-site/src/pages/Explore/index.js
+++ b/gatsby-site/src/pages/Explore/index.js
@@ -35,7 +35,7 @@ const NAV_ITEMS = [
         subNavItems: [
             {
                 name: "all-production",
-                title: "Nationwide"
+                title: "All lands and waters"
             },
             {
                 name: "federal-production",


### PR DESCRIPTION
Fixes #3308

[:turkey: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/production-headings/explore/#production)

Changes proposed in this pull request:

- Changes "Energy production nationwide" to "All lands and waters'
- Changes "Production on federal land nationwide" to "Federal lands and waters"
- Edits nav items accordingly
