### PR TITLE
Adds padding between commodity icons in revenue table

### DIFF
--- a/gatsby-site/src/components/locations/RevenueTypeTable.js
+++ b/gatsby-site/src/components/locations/RevenueTypeTable.js
@@ -312,10 +312,10 @@ const RevenueTypeTable = (props) => {
 				    <tr className="table-arrow_box-category">
 				    	<td colSpan="5">
 					        All commodities
-					        { oilGasExists &&  <span className="icon-padded"> <OilGasIcon /></span> }
-					        { coalExists &&  <span className="icon-padded"><CoalIcon /></span> }
-					        { geothermalExists && <span className="icon-padded"><GeothermalIcon /></span> }
-					        { windExists && <span className="icon-padded"><RenewablesIcon /></span> }
+					        { oilGasExists &&  <span className="icon"> <OilGasIcon /></span> }
+					        { coalExists &&  <span className="icon"><CoalIcon /></span> }
+					        { geothermalExists && <span className="icon"><GeothermalIcon /></span> }
+					        { windExists && <span className="icon"><RenewablesIcon /></span> }
 				      	</td>
 				    </tr>
 				    <RevenueTypeTableRow isNationalPage={props.isNationalPage} commodityName={utils.getDisplayName('All')} commodityData={revenueTypes['All']} year={props.year} />


### PR DESCRIPTION
[:turkey: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/icon-spacing/explore/#revenue)

Changes proposed in this pull request:

- Our commodities icons have been a bit cramped in Gatsby land. This lets them breathe a little.

## Currently
![all commodities with closely spaced icons of gas coal geothermal and wind](https://user-images.githubusercontent.com/32855580/47247744-68c63c80-d3ba-11e8-83eb-50b0e5439e1f.png)

## This PR
![all commodities with spaced icons of gas coal geothermal and wind](https://user-images.githubusercontent.com/32855580/47247775-8f847300-d3ba-11e8-9e3f-621881670e45.png)

