### PR TITLE
Changes 'American Indian' to 'Native American' in disbursements section

### DIFF
--- a/gatsby-site/src/data/fund_names.yml
+++ b/gatsby-site/src/data/fund_names.yml
@@ -20,8 +20,8 @@ Historic Preservation:
     name: How this fund works
     to: /how-it-works/historic-preservation-fund/
 American Indian Tribes:
-  name: American Indian tribes and individuals
-  description: ONRR disburses 100% of revenue collected from resource extraction on American Indian lands back to the Indian tribes and individual Indian landowners.
+  name: Native American tribes and individuals
+  description: ONRR disburses 100% of revenue collected from resource extraction on Native American lands back to tribes, nations, and individuals.
 Other:
   name: Other funds
   description: Some funds are directed back to federal agencies that administer these lands to help cover operational costs. The Ultra-Deepwater Research Program and the Mescal Settlement Agreement also receive $50 million each.


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/content-guidance/explore/#federal-disbursements)

Changes proposed in this pull request:

- Edits `fund-names.yml` to change "American Indian" to "Native American" in accordance with our content guide and federal law
