### PR TITLE
Associates input element with label element using ARIA

### DIFF
--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -22,8 +22,8 @@
 
       <li class="header-nav_item_top">
         <form action='{{ site.baseurl }}/search-results/'>
-          <label class='sr-only' for="q">Search</label>
-          <input type="search" class="search-box header-nav_search" placeholder="Search" id="search-input" name="q" role="search"/>
+          <label id="search-label" class='sr-only' for="q">Search</label>
+          <input type="search" class="search-box header-nav_search" placeholder="Search" id="search-input" name="q" role="search" aria-labelledby="search-label"/>
           <button type="submit" class="header-nav_search_icon icon-search" title="search"><label class="sr-only">Search</label></button>
         </form>
       </li>


### PR DESCRIPTION
Fixes #3306

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/search-label/)

Changes proposed in this pull request:

- Adds `aria-labelledby="search-label"` to associate `input` element with `label`
- Ran Pa11y audit - this resolves one of our accessibility flags
