### PR TITLE
Explains missing data for 2016 disbursements; creates data file for missing data explanations

### DIFF
--- a/gatsby-site/src/components/sections/NationalDisbursements.js
+++ b/gatsby-site/src/components/sections/NationalDisbursements.js
@@ -18,6 +18,7 @@ import YearSelector from '../atoms/YearSelector';
 import StackedBarSingleChartTableRow from '../tables/StackedBarSingleChartTableRow';
 
 import fundedByCongress from '../../data/funded_by_congress.yml';
+import fundExplanation from '../../data/fund_explanation.yml';
 
 
 /** Define data display attributes */
@@ -70,6 +71,7 @@ class NationalDisbursements extends React.Component{
 	render(){
 		let disbursementsForYear = this.state.disbursements[this.state.year];
 		let fundedByCongressForYear = fundedByCongress[this.state.year];
+		let noDataExplanation = fundExplanation[this.state.year];
 
 		return (
 			<section id="federal-disbursements">
@@ -113,7 +115,12 @@ class NationalDisbursements extends React.Component{
 	            							name: "Funded by Congress",
 	            							value: utils.formatToDollarInt(fundedByCongressForYear[fundKey])
 	            						});
-	            				}
+								}
+								
+								let fundNoDataExplanation;
+								if(noDataExplanation && noDataExplanation.fund === fundKey) {
+									fundNoDataExplanation = noDataExplanation.explanation;
+								}
 
 			            		return (<StackedBarSingleChartTableRow 
 			            					key={index+fundKey} 
@@ -126,6 +133,7 @@ class NationalDisbursements extends React.Component{
 			            					chartData={fundDisbursements[fundKey].disbursements}
 			            					maxValue={disbursementsForYear.highestFundValue}
 			            					additionalData={fundAdditionalData}
+											noDataExplanation={fundNoDataExplanation}
 			            					/>);
 	            			}
 	            		})

--- a/gatsby-site/src/components/tables/StackedBarSingleChartTableRow.js
+++ b/gatsby-site/src/components/tables/StackedBarSingleChartTableRow.js
@@ -36,9 +36,15 @@ class StackedBarSingleChartTableRow extends React.Component {
 							className="stacked-bar-legend" />
 					</td>
 					:
-					<td>
-						There is no data about disbursements to {this.props.name} in {this.props.year}.
-					</td>
+					(this.props.noDataExplanation !== undefined) ?
+						<td>
+							{this.props.noDataExplanation}
+						</td>
+						:	
+						<td>
+							There is no data about disbursements to {this.props.name} in {this.props.year}.
+						</td>
+						
 				}
 			</tr>
 		);

--- a/gatsby-site/src/data/fund_explanation.yml
+++ b/gatsby-site/src/data/fund_explanation.yml
@@ -1,0 +1,4 @@
+2016:
+  fund: Historic Preservation Fund
+  no_data: true
+  explanation: There was no disbursement to the Historic Preservation Fund in 2016 because the fund was not reauthorized by Congress until December of 2016.

--- a/gatsby-site/src/data/fund_explanation.yml
+++ b/gatsby-site/src/data/fund_explanation.yml
@@ -1,4 +1,3 @@
 2016:
-  fund: Historic Preservation Fund
-  no_data: true
+  fund: Historic Preservation
   explanation: There was no disbursement to the Historic Preservation Fund in 2016 because the fund was not reauthorized by Congress until December of 2016.


### PR DESCRIPTION
Fixes #3262

[:horse: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/no-data-explain/explore/#federal-disbursements)

Changes proposed in this pull request:

- Replaces default "no data" content for Historic Preservation Fund for 2016
- Adds data file and logic to query for missing data explanations
