### PR TITLE
Adds hover state to icon for testing

### DIFF
--- a/gatsby-site/src/components/layouts/DataAndDocs.js
+++ b/gatsby-site/src/components/layouts/DataAndDocs.js
@@ -2,7 +2,7 @@ import React from 'react';
 import DataAndDocIcon from '-!svg-react-loader!../../img/svg/icon-data-and-docs-circle.svg';
 
 const DataAndDocs = (props) => ( 
-    <span>
+    <span className="icon-link">
         <DataAndDocIcon />
         {props.children === undefined ?
             'Downloads and documentation' :

--- a/gatsby-site/src/styles/components/_icons.scss
+++ b/gatsby-site/src/styles/components/_icons.scss
@@ -29,6 +29,10 @@
   margin: 0 0.1rem;
 }
 
+a .icon-link:hover path {
+  fill: $gray-darkest;
+}
+
 .icon-leading {
   margin-right: 0.4em;
 }


### PR DESCRIPTION
[:horse: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/icon-hover/explore)

@mcharg mentioned an icon hover state might be a user-friendly design behavior to test. This simple hover uses a `fill` property on hover to change the icon's color to gray. We could also `fill-opacity` to desaturate the blue. 

We can test this and find out if it is a useful behavior for users.

![icon-hover](https://user-images.githubusercontent.com/32855580/47944738-b4004500-deba-11e8-87c5-6ffd178aef59.gif)