### PR TITLE
Fixes spacing between utility links in footer

### DIFF
--- a/gatsby-site/src/components/layouts/footer.js
+++ b/gatsby-site/src/components/layouts/footer.js
@@ -21,9 +21,7 @@ const Footer = ({ siteMetadata }) => (
         is powered by <a className="link-active-beta" href="/downloads">open data</a> and <a className="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/">source code</a>. 
         We welcome contributions and comments on <a className="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/issues/new">GitHub</a>.</p>
 
-        <p className="footer-para-small footer-para_last"><a href="https://www.doi.gov/" className="link-beta">Department of the Interior</a> | 
-        <a href="https://www.doi.gov/privacy" className="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" className="link-beta">FOIA</a> | 
-        <a href="https://www.usa.gov/" className="link-beta">USA.gov</a></p>
+        <p className="footer-para-small footer-para_last"><a href="https://www.doi.gov/" className="link-beta">Department of the Interior</a> | <a href="https://www.doi.gov/privacy" className="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" className="link-beta">FOIA</a> | <a href="https://www.usa.gov/" className="link-beta">USA.gov</a></p>
 
       </div>
 


### PR DESCRIPTION
Fixes #3328

[:horse: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-footer/explore)

Changes proposed in this pull request:

- Adds spacing back between utility links in footer component
