### PR TITLE
Fixes styling of explore data button icon on homepage

### DIFF
--- a/gatsby-site/src/components/layouts/buttons/ExploreDataButton/ExploreDataButton.module.css
+++ b/gatsby-site/src/components/layouts/buttons/ExploreDataButton/ExploreDataButton.module.css
@@ -9,13 +9,6 @@
 	padding: 10px 20px;
 }
 
-.root svg{
-	background-color: white;
-	fill: blue;
-	margin-right: 8px;
-	vertical-align: middle;
-}
-
 .root div{
 	display: inline-block;
 	font-weight: bold;

--- a/gatsby-site/src/img/icons/explore-data-square.svg
+++ b/gatsby-site/src/img/icons/explore-data-square.svg
@@ -1,10 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
-<style type="text/css">
-	.explore-data-square{fill:#FFFFFF;}
-</style>
-<path class="explore-data-square" d="M39.6,5.1v76h13.9v-76C53.5,5.1,39.6,5.1,39.6,5.1z M60.4,30.4V81h14V30.4H60.4z M18.8,30.4V81h13.8V30.4H18.8z
-	 M4.9,5.1V95h89.9v-7H11.9V5L4.9,5.1L4.9,5.1z M81.2,81h13.9V55.9H81.2V81z"/>
-</svg>
+<svg width="15px" height="15px" class="icon icon-leading" style="margin-left: -1px; margin-bottom: -1px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22.88 22.79"><path d="M18.73,7.83V20.66h-3.5V7.83ZM13.47,1.37V20.62H10V1.37ZM8.2,7.83V20.66H4.66V7.83ZM1.12,24.16V1.37H2.89v21H24v1.77Zm19.38-3.5V14.24H24v6.42Z" transform="translate(-1.12 -1.37)"/></svg>


### PR DESCRIPTION
[:snake: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/explore-data-button-icon/)

Changes proposed in this pull request:

- Removes `root`-level `svg` selector overriding local styles
- Adds styling for chart icon
