### PR TITLE
Updates what's new section on homepage

### DIFF
--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
@@ -7,11 +7,13 @@ const WhatsNew = (props) => (
   <section className={styles.root+" slab-delta"}>
   	<div className="container-page-wrapper">
 			<h2>What's new</h2>
-			<p>In our latest release on July 12, 2018, we made the following changes:</p>
+			<p>In our latest release on November 21, 2018, we made the following changes:</p>
       <ul className="list-bullet ribbon-card-top-list">
-        <li>Added <Link to="#">2017 federal calendar year production data</Link> to make sure you have the latest</li>
-        <li>Revised <Link to="#">search results</Link> to make it easier to find what you're looking for</li>
+        <li>Released this new homepage, publishing yearly and monthly data summaries for high-demand commodities</li>
+        <li>Introduced a new <Link to="/how-it-works/#disbursements">disbursements section</Link> to provide information about the disbursements process</li>
+        <li>Introduced <Link to="/downloads/federal-revenue-by-month/">revenue by month data file and documentation</Link></li>
       </ul>
+      <p>Review our <a href="https://github.com/ONRR/doi-extractives-data/releases">full release details</a>.</p>
 		</div>
 	</section>
 );


### PR DESCRIPTION
[:snake: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/whats-new/)

Changes proposed in this pull request:

- Updates homepage "what's new" section
