### PR TITLE
Increments version to 4.2.0, with homepage release more than a patch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ url: https://revenuedata.doi.gov
 
 # app version number
 
-version: v4.1.0
+version: v4.2.0
 
 exclude:
   # top-level log

--- a/gatsby-site/gatsby-config.js
+++ b/gatsby-site/gatsby-config.js
@@ -19,7 +19,7 @@ module.exports = {
   siteMetadata: {
     title: 'Natural Resources Revenue Data',
     description: 'This site provides open data about natural resource management on federal lands and waters in the United States, including oil, gas, coal, and other extractive industries.',
-    version: 'v4.1.0',
+    version: 'v4.2.0',
     googleAnalyticsId: GOOGLE_ANALYTICS_ID,
   },
   plugins: [


### PR DESCRIPTION
[:snake: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/homepage-release-version/)

Changes proposed in this pull request:

- Increments site version to v4.2.0
  - More than a patch, this release includes a new homepage built in GatsbyJS
