### PR TITLE
Evens out padding on what's new section

### DIFF
--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
@@ -3,5 +3,5 @@
 
 .root {
 	padding-top: 30px;
-	padding-bottom: 20px;
+	padding-bottom: 30px;
 }

--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
@@ -2,6 +2,6 @@
 @value gray-dark, black-light from colors;
 
 .root {
-	padding-top: 1.875rem;
-	padding-bottom: 2.625rem;
+	padding-top: 1.25rem;
+	padding-bottom: 2.25rem;
 }

--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
@@ -2,6 +2,6 @@
 @value gray-dark, black-light from colors;
 
 .root {
-	padding-top: 30px;
-	padding-bottom: 30px;
+	padding-top: 1.875rem;
+	padding-bottom: 3.375rem;
 }

--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.module.css
@@ -3,5 +3,5 @@
 
 .root {
 	padding-top: 1.875rem;
-	padding-bottom: 3.375rem;
+	padding-bottom: 2.625rem;
 }


### PR DESCRIPTION
Fixes #3394

[:panda_face: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/whats-new-padding/)

Changes proposed in this pull request:

- Evens out padding (adds padding to bottom) of what's new section
