### PR TITLE
Removes colons from key stats table rows

### DIFF
--- a/gatsby-site/src/components/charts/ChartLegend.js
+++ b/gatsby-site/src/components/charts/ChartLegend.js
@@ -39,7 +39,7 @@ class ChartLegend extends React.Component {
 											<div className={"chart-legend-"+utils.formatToSlug(key)} />
 										</td>
 										<td>
-											{this.getKeyDisplayName(key)}:
+											{this.getKeyDisplayName(key)}
 										</td>
 										<td>
 											{ this.props.dataFormatFunc ?
@@ -57,7 +57,7 @@ class ChartLegend extends React.Component {
 						<td>
 						</td>
 						<td>
-							Total:
+							Total
 						</td>
 						<td>
 							{ this.props.dataFormatFunc ?
@@ -72,7 +72,7 @@ class ChartLegend extends React.Component {
 							return (
 								<tr key={index} className="chart-legend-additional-data-row">
 									<td />
-									<td>{data.name}:</td>
+									<td>{data.name}</td>
 									<td>{data.value}</td>
 								</tr>)
 						})

--- a/gatsby-site/src/components/charts/ChartLegend.js
+++ b/gatsby-site/src/components/charts/ChartLegend.js
@@ -39,7 +39,7 @@ class ChartLegend extends React.Component {
 											<div className={"chart-legend-"+utils.formatToSlug(key)} />
 										</td>
 										<td>
-											{this.getKeyDisplayName(key)}
+											{this.getKeyDisplayName(key)}:
 										</td>
 										<td>
 											{ this.props.dataFormatFunc ?
@@ -57,7 +57,7 @@ class ChartLegend extends React.Component {
 						<td>
 						</td>
 						<td>
-							Total
+							Total:
 						</td>
 						<td>
 							{ this.props.dataFormatFunc ?
@@ -72,7 +72,7 @@ class ChartLegend extends React.Component {
 							return (
 								<tr key={index} className="chart-legend-additional-data-row">
 									<td />
-									<td>{data.name}</td>
+									<td>{data.name}:</td>
 									<td>{data.value}</td>
 								</tr>)
 						})

--- a/gatsby-site/src/components/charts/ChartLegendStandard/ChartLegendStandard.js
+++ b/gatsby-site/src/components/charts/ChartLegendStandard/ChartLegendStandard.js
@@ -55,7 +55,7 @@ class ChartLegendStandard extends React.Component {
 											<div className={(styleMap && styleMap[key])} />
 										</td>
 										<td>
-											{this.getKeyDisplayName(key)}:
+											{this.getKeyDisplayName(key)}
 										</td>
 										<td>
 											{ this.props.dataFormatFunc ?
@@ -74,7 +74,7 @@ class ChartLegendStandard extends React.Component {
 											<div className={(styleMap && styleMap[key])} />
 										</td>
 										<td>
-											{this.getKeyDisplayName(key)}:
+											{this.getKeyDisplayName(key)}
 										</td>
 										<td>
 											-
@@ -86,7 +86,7 @@ class ChartLegendStandard extends React.Component {
 					}
 					<tr className={styles.chartLegendStandard_TotalRow}>
 						<td colSpan="2">
-							Total:
+							Total
 						</td>
 						<td>
 							{ this.props.dataFormatFunc ?


### PR DESCRIPTION
[:panda_face: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/proct-o-colect-omy/)

Changes proposed in this pull request:

- Removes colons from table rows in Data summary ("key stats") section of homepage
