### PR TITLE
added hover state to chart legend when the bar chart has a hover stat…

### DIFF
--- a/gatsby-site/src/components/charts/ChartLegendStandard/ChartLegendStandard.js
+++ b/gatsby-site/src/components/charts/ChartLegendStandard/ChartLegendStandard.js
@@ -6,10 +6,9 @@ import utils from '../../../js/utils';
 
 import styles from "./ChartLegendStandard.module.css"
 
-
 /**
  * Chart Legend Standard is used to display rows of data keys and values. Each data key can be 
- * associated with a format function, a color(using css) and a display name.
+ * associated with a format function, a css class and a display name.
  */
 class ChartLegendStandard extends React.Component {
 
@@ -27,20 +26,17 @@ class ChartLegendStandard extends React.Component {
 	}
 
 	render() {
-		let data = this.props.data;
-		let sortOrder = (this.props.displayConfig && this.props.displayConfig.sortOrder) ? this.props.displayConfig.sortOrder : Object.keys(data);
+		let {data, styleMap, units, sortOrder, headerName} = this.props;
 		// reverse the order to show from bottom to top per requirements
-		sortOrder = sortOrder.slice().reverse();
-
-		let styleMap = this.props.displayConfig && this.props.displayConfig.styleMap;
-		let units = this.props.displayConfig && this.props.displayConfig.units;
+		sortOrder = (sortOrder) ? sortOrder.slice().reverse() : Object.keys(data);
 
 		let total = 0;
+
 		return(
 			<table className={styles.chartLegendStandard}>
 				<thead>
       		<tr>
-        		<th colSpan="2">Source</th>
+        		<th colSpan="2">{headerName || ""}</th>
         		<th>{this.props.dataKey && this.props.dataKey+(units === "$" ? "" : " ("+units+")")}</th>
         	</tr>
       	</thead>
@@ -103,16 +99,20 @@ class ChartLegendStandard extends React.Component {
 }
 
 ChartLegendStandard.propTypes = {
-	/** Units label to display for the values */
-	units: PropTypes.string,
 	/** Array of key value pairs */
 	data: PropTypes.object.isRequired,
-	/** Defines the display name/info of the data keys in the chart. Keys should match the data keys */
-	displayNames: PropTypes.object,
 	/** A function that will be applied on each data item of the chart data */
 	dataFormatFunc: PropTypes.func,
-	/** Specify a class name to be added to the outer element */
-	className: PropTypes.string
+	/** Defines the display name/info of the data keys in the chart. Keys should match the data keys */
+	displayNames: PropTypes.object,
+	/** Define the name of the header that display above the data keys **/
+	headerName: PropTypes.string,
+	/** Specify the sort order of the data keys **/
+	sortOrder: PropTypes.array,
+	/** Map data keys to a style class **/
+	styleMap: PropTypes.styleMap,
+	/** Units label to display for the values */
+	units: PropTypes.string,
 }
 
 export default ChartLegendStandard;

--- a/gatsby-site/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
+++ b/gatsby-site/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
@@ -42,6 +42,27 @@ class StackedBarChartLayout extends React.Component{
     }
   }
 
+  getStyleMap(){
+    return (this.state.chartDataKeyHovered && 
+        (this.props.chartDisplayConfig.styleMap && this.props.chartDisplayConfig.styleMap.hover)) ? 
+        this.props.chartDisplayConfig.styleMap.hover : this.props.chartDisplayConfig.styleMap;
+  }
+
+  getChartLegend() {
+
+    return (
+      <ChartLegendStandard 
+        headerName={this.props.chartLegendHeaderName} 
+        data={(this.state.chartLegendDataHovered && this.state.chartLegendDataHovered[0]) || this.state.chartLegendData[0]}
+        dataKey={this.state.chartDataKeyHovered || this.state.chartDataKeySelected}
+        dataFormatFunc={this.props.chartLegendDataFormatFunc}
+        styleMap={this.getStyleMap()}
+        sortOrder={this.props.chartDisplayConfig.sortOrder}
+        units={this.props.chartDisplayConfig.units} >
+      </ChartLegendStandard>
+    );
+  }
+
   render() {
     let props = this.props;
 
@@ -65,33 +86,21 @@ class StackedBarChartLayout extends React.Component{
         {this.state.chartLegendData &&
           <MediaQuery maxWidth={768}>
             <Accordion id={utils.formatToSlug(props.chartDisplayConfig.title)} text={["Show details", "Hide details"]}>
-              <ChartLegendStandard 
-                displayConfig={props.chartDisplayConfig}
-                header={props.chartLegendHeader} 
-                units={props.chartLegendUnits}
-                data={(this.state.chartLegendDataHovered && this.state.chartLegendDataHovered[0]) || this.state.chartLegendData[0]}
-                dataKey={this.state.chartDataKeyHovered || this.state.chartDataKeySelected}
-                dataFormatFunc={props.chartLegendDataFormatFunc} >
-              </ChartLegendStandard>
+              {this.getChartLegend()}
             </Accordion>
           </MediaQuery>
         }
         {this.state.chartLegendData &&
           <MediaQuery minWidth={769}>
-            <ChartLegendStandard 
-              displayConfig={props.chartDisplayConfig}
-              header={props.chartLegendHeader}  
-              units={props.chartLegendUnits}
-              data={(this.state.chartLegendDataHovered && this.state.chartLegendDataHovered[0]) || this.state.chartLegendData[0]}
-              dataKey={this.state.chartDataKeyHovered || this.state.chartDataKeySelected}
-              dataFormatFunc={props.chartLegendDataFormatFunc} >
-            </ChartLegendStandard>
+            {this.getChartLegend()}
           </MediaQuery>
         }
       </div>
     );
   }
 }
+
+
 
 StackedBarChartLayout.propTypes = {
     /** The object that contains properties for display */

--- a/gatsby-site/src/components/sections/KeyStatsSection/KeyStatsSection.js
+++ b/gatsby-site/src/components/sections/KeyStatsSection/KeyStatsSection.js
@@ -29,6 +29,8 @@ const DROPDOWN_VALUES ={
 	Calendar: "calendar"
 }
 
+const CHART_HEADER_NAME = "Source";
+
 const CHART_SORT_ORDER = [CONSTANTS.FEDERAL_ONSHORE, CONSTANTS.FEDERAL_OFFSHORE,CONSTANTS.NATIVE_AMERICAN];
 
 const CHART_STYLE_MAP = {
@@ -36,6 +38,11 @@ const CHART_STYLE_MAP = {
 	[CONSTANTS.FEDERAL_OFFSHORE]: styles.federalOffshore,
 	[CONSTANTS.FEDERAL_ONSHORE]: styles.federalOnshore,
 	[CONSTANTS.NATIVE_AMERICAN]: styles.nativeAmerican,
+	hover : {
+		[CONSTANTS.FEDERAL_OFFSHORE]: styles.federalOffshoreHover,
+		[CONSTANTS.FEDERAL_ONSHORE]: styles.federalOnshoreHover,
+		[CONSTANTS.NATIVE_AMERICAN]: styles.nativeAmericanHover,
+	}
 };
 
 const MAX_CHART_BAR_SIZE = 15;
@@ -193,6 +200,8 @@ class KeyStatsSection extends React.Component{
 												sortOrder: CHART_SORT_ORDER,
 											}}
 
+											chartLegendHeaderName={CHART_HEADER_NAME}
+
 											chartData={this.state[CONSTANTS.PRODUCTION_VOLUMES_OIL_KEY].Data}
 
 											chartLegendDataFormatFunc={utils.formatToCommaInt}
@@ -218,6 +227,8 @@ class KeyStatsSection extends React.Component{
 												sortOrder: CHART_SORT_ORDER,
 											}}
 
+											chartLegendHeaderName={CHART_HEADER_NAME}
+
 											chartData={this.state[CONSTANTS.PRODUCTION_VOLUMES_GAS_KEY].Data}
 
 											chartLegendDataFormatFunc={utils.formatToCommaInt}
@@ -242,6 +253,8 @@ class KeyStatsSection extends React.Component{
 												styleMap: CHART_STYLE_MAP,
 												sortOrder: CHART_SORT_ORDER,
 											}}
+
+											chartLegendHeaderName={CHART_HEADER_NAME}
 
 											chartData={this.state[CONSTANTS.PRODUCTION_VOLUMES_COAL_KEY].Data}
 
@@ -302,6 +315,8 @@ class KeyStatsSection extends React.Component{
 												sortOrder: CHART_SORT_ORDER,
 											}}
 
+											chartLegendHeaderName={CHART_HEADER_NAME}
+
 											chartData={this.state[CONSTANTS.REVENUES_ALL_KEY].Data}
 
 											chartLegendDataFormatFunc={utils.formatToDollarInt}
@@ -333,6 +348,8 @@ class KeyStatsSection extends React.Component{
 												sortOrder: CHART_SORT_ORDER,
 											}}
 
+											chartLegendHeaderName={CHART_HEADER_NAME}
+
 											chartData={this.state[CONSTANTS.DISBURSEMENTS_ALL_KEY].Data}
 
 											chartLegendDataFormatFunc={utils.formatToDollarInt}
@@ -351,22 +368,6 @@ class KeyStatsSection extends React.Component{
 
 					</section>
 				</div>
-				<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4" viewBox="0 0 4 4">
-					<defs> 
-						<pattern id="onshore-offshore-pattern-selected" patternUnits="userSpaceOnUse" width="4" height="4"> 
-							<rect y="0" fill={styles.federalOnshoreColor_selected}  width="4" height="4"/>
-							<path fill={styles.federalOffshoreColor_selected}  d="M1,3h1v1H1V3z M3,1h1v1H3V1z"/>
-						</pattern>
-					</defs>
-				</svg>
-				<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4" viewBox="0 0 4 4">
-					<defs> 
-						<pattern id="onshore-offshore-pattern" patternUnits="userSpaceOnUse" width="4" height="4"> 
-							<rect y="0" fill={styles.federalOnshoreColor} width="4" height="4"/>
-							<path fill={styles.federalOffshoreColor} d="M1,3h1v1H1V3z M3,1h1v1H3V1z"/>
-						</pattern>
-					</defs>
-				</svg>
 
 			</section>
 		);

--- a/gatsby-site/src/components/sections/KeyStatsSection/KeyStatsSection.module.css
+++ b/gatsby-site/src/components/sections/KeyStatsSection/KeyStatsSection.module.css
@@ -22,9 +22,6 @@
 	background-color: federalOffshoreColor_selected;
 	fill: federalOffshoreColor;
 }
-.federalOnshoreOffshore {
-	fill: url("#onshore-offshore-pattern");
-}
 .nativeAmerican {
 	background-color: nativeAmericanColor_selected;
 	fill: nativeAmericanColor;
@@ -37,9 +34,6 @@
 }
 .chartBar[selected=true] .federalOffshore{
 	fill: federalOffshoreColor_selected;
-}
-.chartBar[selected=true] .federalOnshoreOffshore{
-	fill: url("#onshore-offshore-pattern-selected");
 }
 .chartBar[selected=true] .nativeAmerican{
 	fill: nativeAmericanColor_selected;
@@ -54,15 +48,23 @@
 	fill: federalOffshoreColor_selected;
 	opacity: 0.8;
 }
-.chartBar:hover .federalOnshoreOffshore{
-	fill: url("#onshore-offshore-pattern-selected");
-	opacity: 0.8;
-}
 .chartBar:hover .nativeAmerican{
 	fill: nativeAmericanColor_selected;
 	opacity: 0.8;
 }
 
+.federalOnshoreHover {
+	background-color: federalOnshoreColor_selected;
+	opacity: 0.8;
+}
+.federalOffshoreHover {
+	background-color: federalOffshoreColor_selected;
+	opacity: 0.8;
+}
+.nativeAmericanHover {
+	background-color: nativeAmericanColor_selected;
+	opacity: 0.8;
+}
 
 .root h2 {
 	border-bottom: 10px solid green-light;


### PR DESCRIPTION
Fixes #3392 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-chart-legend-hover//)

Changes proposed in this pull request:

- Added hover state to the chart legend.  Address this issue:
"On hover, the swatches in the table should change to the hover color."
-
-
