### PR TITLE
Removes smooth-scrolling behavior

### DIFF
--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -22,7 +22,6 @@ time, mark, audio, video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
-  scroll-behavior: smooth;
 }
 
 /* HTML5 display-role reset for older browsers */

--- a/gatsby-site/src/styles/_reset.scss
+++ b/gatsby-site/src/styles/_reset.scss
@@ -22,7 +22,6 @@ time, mark, audio, video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
-  scroll-behavior: smooth;
 }
 
 /* HTML5 display-role reset for older browsers */


### PR DESCRIPTION
Fixes #3420

[:panda_face: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/remove-smooth/)

Changes proposed in this pull request:

We added smooth scrolling (animated scrolling to sections of a given page) with the understanding that we were going to evaluate the benefits versus drawbacks over time.

## Benefits
The user benefit we were seeking was to help users orient themselves on the page when using in-page navigation. This was particularly relevant for the explore data page, which contains multiple sections of content. We observed users getting disoriented when navigating sections of the page. Default browser behavior "jumps" to the chosen section. Smooth scroll animates to the section, so the user receives a queue as to the relative position of the origin and destination.

## Drawbacks
We knew some users have negative [vestibular reactions](https://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity) to animating behaviors, such as [parallax scrolling](https://en.wikipedia.org/wiki/Parallax_scrolling), and that it was possible smooth scrolling could trigger similar sensitivity to motion.

## Outcome
We heard from one user that the behavior triggered vertigo. And while the smooth-scroll behavior can be turned off in a user's browser settings, we assume many users aren't aware of that setting (or don't know how to use it). Since we heard this negative reaction, but we didn't hear decidedly positive reactions compatible with our intent, we've decided to deactivate the behavior.
