### PR TITLE
Adds proper hash for homepage-->disbursement recipients

### DIFF
--- a/gatsby-site/src/pages/index.js
+++ b/gatsby-site/src/pages/index.js
@@ -134,7 +134,7 @@ class HomePage extends React.Component {
               <div className={styles.tabContentAside}>
                 <h5>Explore disbursements data</h5>
                 <div className={styles.linkContainer}>
-                  <ExploreDataLink to="/explore/#recipients">By recipient</ExploreDataLink>
+                  <ExploreDataLink to="/explore/#by-fund">By recipient</ExploreDataLink>
                   <DownloadDataLink to="/downloads/disbursements">Downloads and documentation</DownloadDataLink>
                 </div>
               </div>


### PR DESCRIPTION
[:panda_face: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-disbursements-hash/)

Changes proposed in this pull request:

- Changes `#recipient` to `#by-fund` to apply proper fragment identifier

Prior to last release, I added an `id` attribute to the disbursements table and changed the corresponding link fragment in an effort to fix a link issue. The `id` didn't follow into production, but the link did. This fix reverts the link back to the original `id`.