### PR TITLE
Patch release to dev

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ url: https://revenuedata.doi.gov
 
 # app version number
 
-version: v4.2.1
+version: v4.2.2
 
 exclude:
   # top-level log

--- a/gatsby-site/gatsby-config.js
+++ b/gatsby-site/gatsby-config.js
@@ -19,7 +19,7 @@ module.exports = {
   siteMetadata: {
     title: 'Natural Resources Revenue Data',
     description: 'This site provides open data about natural resource management on federal lands and waters in the United States, including oil, gas, coal, and other extractive industries.',
-    version: 'v4.2.1',
+    version: 'v4.2.2',
     googleAnalyticsId: GOOGLE_ANALYTICS_ID,
   },
   plugins: [

--- a/gatsby-site/src/components/sections/KeyStatsSection/KeyStatsSection.js
+++ b/gatsby-site/src/components/sections/KeyStatsSection/KeyStatsSection.js
@@ -40,6 +40,11 @@ const CHART_STYLE_MAP = {
 
 const MAX_CHART_BAR_SIZE = 15;
 
+const PRODUCTION_VOLUMES_FISCAL_YEAR = "ProductionVolumesFiscalYear";
+const PRODUCTION_VOLUMES_CALENDAR_YEAR = "ProductionVolumesCalendarYear";
+const REVENUES_FISCAL_YEAR = "RevenuesFiscalYear";
+const REVENUES_CALENDAR_YEAR = "RevenuesCalendarYear";
+
 class KeyStatsSection extends React.Component{
 
 	constructor(props){
@@ -170,10 +175,10 @@ class KeyStatsSection extends React.Component{
 													name:"Most recent 12 months",
 													default: (this.state.productionPeriod === DROPDOWN_VALUES.Recent)},
 												{key:DROPDOWN_VALUES.Fiscal,
-													name:"Fiscal year 2017",
+													name:"Fiscal year "+this.state[PRODUCTION_VOLUMES_FISCAL_YEAR][CONSTANTS.PRODUCTION_VOLUMES_OIL_KEY],
 													default: (this.state.productionPeriod === DROPDOWN_VALUES.Fiscal)}, 
 												{key:DROPDOWN_VALUES.Calendar,
-													name:"Calendar year 2017",
+													name:"Calendar year "+this.state[PRODUCTION_VOLUMES_CALENDAR_YEAR][CONSTANTS.PRODUCTION_VOLUMES_OIL_KEY],
 													default: (this.state.productionPeriod === DROPDOWN_VALUES.Calendar)}]}></DropDown>
 									</div>
 								}
@@ -280,10 +285,10 @@ class KeyStatsSection extends React.Component{
 													name:"Most recent 12 months",
 													default: (this.state.revenuePeriod === DROPDOWN_VALUES.Recent)},
 												{key:DROPDOWN_VALUES.Fiscal,
-													name:"Fiscal year 2017",
+													name:"Fiscal year "+this.state[REVENUES_FISCAL_YEAR][CONSTANTS.REVENUES_ALL_KEY],
 													default: (this.state.revenuePeriod === DROPDOWN_VALUES.Fiscal)}, 
 												{key:DROPDOWN_VALUES.Calendar,
-													name:"Calendar year 2017",
+													name:"Calendar year "+this.state[REVENUES_CALENDAR_YEAR][CONSTANTS.REVENUES_ALL_KEY],
 													default: (this.state.revenuePeriod === DROPDOWN_VALUES.Calendar)}]}></DropDown>
 									</div>
 								}
@@ -380,6 +385,10 @@ export default connect(
   						[CONSTANTS.PRODUCTION_VOLUMES_COAL_KEY]: state[CONSTANTS.PRODUCTION_VOLUMES_KEY][CONSTANTS.PRODUCTION_VOLUMES_COAL_KEY],
   						[CONSTANTS.REVENUES_ALL_KEY]: state[CONSTANTS.REVENUES_KEY][CONSTANTS.REVENUES_ALL_KEY],
   						[CONSTANTS.DISBURSEMENTS_ALL_KEY]: state[CONSTANTS.DISBURSEMENTS_KEY][CONSTANTS.DISBURSEMENTS_ALL_KEY],
+  						[PRODUCTION_VOLUMES_FISCAL_YEAR]: state[CONSTANTS.PRODUCTION_VOLUMES_KEY][CONSTANTS.FISCAL_YEAR_KEY],
+  						[PRODUCTION_VOLUMES_CALENDAR_YEAR]: state[CONSTANTS.PRODUCTION_VOLUMES_KEY][CONSTANTS.CALENDAR_YEAR_KEY],
+  						[REVENUES_FISCAL_YEAR]: state[CONSTANTS.REVENUES_KEY][CONSTANTS.FISCAL_YEAR_KEY],
+  						[REVENUES_CALENDAR_YEAR]: state[CONSTANTS.REVENUES_KEY][CONSTANTS.CALENDAR_YEAR_KEY],
   					}),
   dispatch => ({	productionVolumesByYear: (key, filter) => dispatch(productionVolumesByYearAction(key, filter)),
   								productionVolumesByMonth: (key, filter) => dispatch(productionVolumesByMonthAction(key, filter)),

--- a/gatsby-site/src/js/constants.js
+++ b/gatsby-site/src/js/constants.js
@@ -6,6 +6,9 @@ module.exports = Object.freeze({
 	REVENUES_KEY: 'revenues',
 	PRODUCTION_VOLUMES_KEY: 'productionVolumes',
   DISBURSEMENTS_KEY: 'federalDisbursements',
+  FISCAL_YEAR_KEY: 'FiscalYear',
+  CALENDAR_YEAR_KEY: 'CalendarYear',
+
 
   // Disbursements data keys for redux store
   DISBURSEMENTS_ALL_KEY: 'disbursementsAll',

--- a/gatsby-site/src/state/reducers/production-volumes.js
+++ b/gatsby-site/src/state/reducers/production-volumes.js
@@ -4,12 +4,12 @@ import CONSTANTS from '../../js/constants';
 import utils from '../../js/utils';
 
 const initialState = {
-	FiscalYear: {
+	[CONSTANTS.FISCAL_YEAR_KEY]: {
 		[CONSTANTS.PRODUCTION_VOLUMES_OIL_KEY]: undefined,
 		[CONSTANTS.PRODUCTION_VOLUMES_GAS_KEY]: undefined,
 		[CONSTANTS.PRODUCTION_VOLUMES_COAL_KEY]: undefined
 	},
-	CalendarYear: {
+	[CONSTANTS.CALENDAR_YEAR_KEY]: {
 		[CONSTANTS.PRODUCTION_VOLUMES_OIL_KEY]: undefined,
 		[CONSTANTS.PRODUCTION_VOLUMES_GAS_KEY]: undefined,
 		[CONSTANTS.PRODUCTION_VOLUMES_COAL_KEY]: undefined
@@ -69,14 +69,14 @@ export default (state = initialState, action) => {
  **/
 
 const getFiscalCalendarYear = (key, source,fiscalYear,calendarYear) => {
-	if(source === undefined) return {FiscalYear: undefined, CalendarYear: undefined};
+	if(source === undefined) return {[CONSTANTS.FISCAL_YEAR_KEY]: undefined, [CONSTANTS.CALENDAR_YEAR_KEY]: undefined};
 	
 	let fiscalYearItem = source.find(item => (item.data.ProductionMonth === "September"));
 	let calendarYearItem = source.find(item => (item.data.ProductionMonth === "December"));
 	fiscalYear[key] = (fiscalYearItem && parseInt(fiscalYearItem.data.ProductionYear));
 	calendarYear[key] = (calendarYearItem && parseInt(calendarYearItem.data.ProductionYear));
-	return {FiscalYear: fiscalYear, 
-					CalendarYear: calendarYear};
+	return {[CONSTANTS.FISCAL_YEAR_KEY]: fiscalYear, 
+					[CONSTANTS.CALENDAR_YEAR_KEY]: calendarYear};
 }
 
 /** 


### PR DESCRIPTION

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/3248-fiscal-year-label/)

Changes proposed in this pull request:

- Propagates patch release to `dev`, so `dev` is up to date with `master`
