### PR TITLE
Adds explanation for monthly and annual totals

### DIFF
--- a/_downloads/federal-production-by-month.md
+++ b/_downloads/federal-production-by-month.md
@@ -59,7 +59,7 @@ We update this production data every month, but final production numbers aren't 
 
 The sum of 12-month production totals for a given calendar or fiscal year may not add up to the annual total found in the [production by year data]({{site.baseurl}}//downloads/federal-production/). While the production volume (amount of a commodity coming out of the ground) doesn't change, the way it is accounted for might. There are a two main reasons why:
 
-- Operators may not report on time, meaning production for a past month might increase when the operator submits the report and the production data is updated
+- Operators may not report on time, meaning production for a past month might increase when the operator submits the report and ONRR updates the data.
 
 - The Bureau of Land Management may choose to change agreements and units after production. These changes may affect the allocation of the production volume, changing the data. <br><br>For example, changing an agreement retroactively may change the allocation of production among states, the federal government, and Native American tribes and individuals. As a result, the apportioned totals in the data would change.
 

--- a/_downloads/federal-production-by-month.md
+++ b/_downloads/federal-production-by-month.md
@@ -10,6 +10,8 @@ nav_items:
     title: Scope
   - name: data-publication
     title: Data publication
+  - name: monthly-totals-and-annual-totals
+    title: Monthly totals and annual totals  
   - name: data-dictionary
     title: Data dictionary
     subnav_items:

--- a/_downloads/federal-production-by-month.md
+++ b/_downloads/federal-production-by-month.md
@@ -53,6 +53,14 @@ This dataset includes natural resource production for U.S. federal lands and off
 
 We update this production data every month, but final production numbers aren't available for 3-4 months. For example, the most recent production data for a file updated in November will be from July or August.
 
+## Monthly totals and annual totals
+
+The sum of 12-month production totals for a given calendar or fiscal year may not add up to the annual total found in the [production by year data]({{site.baseurl}}//downloads/federal-production/). While the production volume (amount of a commodity coming out of the ground) doesn't change, the way it is accounted for might. There are a two main reasons why:
+
+- Operators may not report on time, meaning production for a past month might increase when the operator submits the report and the production data is updated
+
+- The Bureau of Land Management may choose to change agreements and units after production. These changes may affect the allocation of the production volume, changing the data. <br><br>For example, changing an agreement retroactively may change the allocation of production among states, the federal government, and Native American tribes and individuals. As a result, the apportioned totals in the data would change.
+
 ## Data dictionary
 
 ### Fields and definitions

--- a/_downloads/federal-production-by-month.md
+++ b/_downloads/federal-production-by-month.md
@@ -57,7 +57,7 @@ We update this production data every month, but final production numbers aren't 
 
 ## Monthly totals and annual totals
 
-The sum of 12-month production totals for a given calendar or fiscal year may not add up to the annual total found in the [production by year data]({{site.baseurl}}//downloads/federal-production/). While the production volume (amount of a commodity coming out of the ground) doesn't change, the way it is accounted for might. There are a two main reasons why:
+The sum of 12-month production totals for a given calendar or fiscal year may not add up to the annual total found in the [production by year data]({{site.baseurl}}//downloads/federal-production/). While the production volume (amount of a commodity coming out of the ground) doesn't change, the way it is accounted for might. There are two main reasons why:
 
 - Operators may not report on time, meaning production for a past month might increase when the operator submits the report and ONRR updates the data.
 


### PR DESCRIPTION
Fixes #3384 

[:heavy_plus_sign: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/monthly-production/downloads/federal-production-by-month/)

Changes proposed in this pull request:

- Adds scope content to explain why 12-month production volumes may not add up to annual production volumes for respective commodities
