### PR TITLE
Tabordion styling on homepage

### DIFF
--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -83,6 +83,10 @@
 		width: 100%;
 	}
 
+	.tab + .tab {
+		border-top: none;
+	}
+
 	.tabPanelContainer {
 		top: 0px;
 	}

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -76,9 +76,7 @@
 	}
 	.tab {
 		float: none;
-		border-top: 1px solid gray-light;
-		border-right: 1px solid gray-light;
-		border-left: 1px solid gray-light;
+		border: 1px solid gray-light;
 		text-align: left;
 		width: 100%;
 	}

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -14,7 +14,6 @@
 
 .tab {
 	background-color: white;
-	border: 1px solid gray-light;
 	color: gray-darkest;
 	cursor: pointer;
 	font-size: 16px;
@@ -38,7 +37,6 @@
 
 .tabPanelContainer {
 	background-color: gray-pale;
-	border: 1px solid gray-light;
   overflow: hidden;
   position: relative;
   top: -1px;
@@ -69,10 +67,12 @@
 	}
 	.tab {
 		float: none;
+		border: 1px solid gray-light;
 		text-align: left;
 		width: 100%;
 	}
 	.tabPanelContainer {
-	  top: 0px;
+		top: 0px;
+		border: 1px solid gray-light;
 	}
 }

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -15,6 +15,9 @@
 
 .tab {
 	background-color: white;
+	border-left: .75px solid gray-light;
+	border-top: .75px solid gray-light;
+	border-bottom: .75px solid gray-light;
 	color: gray-darkest;
 	cursor: pointer;
 	font-size: 16px;
@@ -24,6 +27,10 @@
 	text-align: center;
 	float: left;
   z-index: 10;
+}
+
+.tab:last-of-type {
+	border-right: .75px solid gray-light;
 }
 
 .tab:hover{
@@ -38,6 +45,7 @@
 
 .tabPanelContainer {
 	background-color: gray-pale;
+	border: .75px solid gray-light;
   overflow: hidden;
   position: relative;
   top: -1px;
@@ -68,12 +76,10 @@
 	}
 	.tab {
 		float: none;
-		border: 1px solid gray-light;
 		text-align: left;
 		width: 100%;
 	}
 	.tabPanelContainer {
 		top: 0px;
-		border: 1px solid gray-light;
 	}
 }

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -6,6 +6,7 @@
 }
 
 .tabContainer {
+	margin-top: 5rem;
   display: flex;
   justify-content: flex-start;
   flex-wrap: nowrap;

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -76,10 +76,15 @@
 	}
 	.tab {
 		float: none;
+		border-top: 1px solid gray-light;
+		border-right: 1px solid gray-light;
+		border-left: 1px solid gray-light;
 		text-align: left;
 		width: 100%;
 	}
+
 	.tabPanelContainer {
 		top: 0px;
 	}
+
 }

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -83,10 +83,6 @@
 		width: 100%;
 	}
 
-	.tab + .tab {
-		border-top: none;
-	}
-
 	.tabPanelContainer {
 		top: 0px;
 	}

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -15,9 +15,9 @@
 
 .tab {
 	background-color: white;
-	border-left: .75px solid gray-light;
-	border-top: .75px solid gray-light;
-	border-bottom: .75px solid gray-light;
+	border-top: 1px solid gray-light;
+	border-left: 1px solid gray-light;
+	border-bottom: 1px solid gray-light;
 	color: gray-darkest;
 	cursor: pointer;
 	font-size: 16px;
@@ -30,7 +30,7 @@
 }
 
 .tab:last-of-type {
-	border-right: .75px solid gray-light;
+	border-right: 1px solid gray-light;
 }
 
 .tab:hover{

--- a/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
+++ b/gatsby-site/src/components/layouts/Tabordion/Tabordion.module.css
@@ -45,7 +45,7 @@
 
 .tabPanelContainer {
 	background-color: gray-pale;
-	border: .75px solid gray-light;
+	border: 1px solid gray-light;
   overflow: hidden;
   position: relative;
   top: -1px;

--- a/gatsby-site/src/pages/index.module.css
+++ b/gatsby-site/src/pages/index.module.css
@@ -11,7 +11,7 @@
 	display: flex;
 	flex-wrap: nowrap;
 	justify-content: space-between;
-	padding: 20px;
+	padding: 2.2rem 1.3rem 1.3rem 1.3rem;
 }
 
 .tabContent {


### PR DESCRIPTION
Part of homepage bug fixes (3392 - padding between navigation and tabs)

[:mag: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/cleaner-tabordion/)

Changes proposed in this pull request:

- Removes border from tabs and tab container on desktop
  - Adds back in for mobile accordion treatment
- Adds more padding to the top of tab panel paragraph
- Adds margin between the main navigation and tabs
  - Same margin as existing margin before and after map

## Production
![homepage with tabs for overview, production, revenue, disbursements, with borders around the tabs and tab panel](https://user-images.githubusercontent.com/32855580/49490802-76b70c00-f806-11e8-9fe4-bc5defe5a250.png)

## This PR
![homepage with tabs for overview, production, revenue, disbursements, with no borders around the tabs and tab panel](https://user-images.githubusercontent.com/32855580/49490844-bb42a780-f806-11e8-8472-c5fc8497375f.png)

