### PR TITLE
Updates what's new section of homepage for Dec 6 release

### DIFF
--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
@@ -7,11 +7,11 @@ const WhatsNew = (props) => (
   <section className={styles.root+" slab-delta"}>
   	<div className="container-page-wrapper">
 			<h2>What's new</h2>
-			<p>In our latest release on November 21, 2018, we made the following changes:</p>
+			<p>In our latest release on December 6, 2018, we made the following changes:</p>
       <ul className="list-bullet ribbon-card-top-list">
-        <li>Released this new homepage, publishing yearly and monthly data summaries for high-demand commodities</li>
-        <li>Introduced a new <Link to="/how-it-works/#disbursements">disbursements section</Link> to provide information about the disbursements process</li>
-        <li>Introduced <Link to="/downloads/federal-revenue-by-month/">revenue by month data file and documentation</Link></li>
+        <li>Launched a <Link to="/blog">blog about how we work on this site</Link></li>
+        <li>Updated monthly production data</li>
+        <li>Added documentation about <Link to="/downloads/federal-production-by-month/#monthly-totals-and-annual-totals">monthly and annual production volumes</Link></li>
       </ul>
       <p>Review our <a href="https://github.com/ONRR/doi-extractives-data/releases">full release details</a>.</p>
 		</div>


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/whats-new-12-6-18/)

Changes proposed in this pull request:

- Updates what's new section for upcoming release
