### PR TITLE
Adds google analytics id to blog config

### DIFF
--- a/blog-site/gatsby-config.js
+++ b/blog-site/gatsby-config.js
@@ -2,6 +2,11 @@
 // https://github.com/18F/federalist-garden-build#variables-exposed-during-builds
 const BASEURL = process.env.BASEURL || '';
 
+// Federalist provides the google_analytics env variable
+const GOOGLE_ANALYTICS_ID = (process.env.google_analytics) ?
+                (process.env.google_analytics[process.env.BRANCH] || process.env.google_analytics.default)
+                :
+                "UA-48605964-8";
 
 module.exports = {
   siteMetadata: {
@@ -58,7 +63,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        //trackingId: `ADD YOUR TRACKING ID HERE`,
+        trackingId: GOOGLE_ANALYTICS_ID,
       },
     },
     `gatsby-plugin-offline`,


### PR DESCRIPTION
Fixes #3460

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-analytics/)

Changes proposed in this pull request:

- Adds google analytics script and id to blog
