### PR TITLE
Adds "total revenue for year" sentence to revenue intro (like disbursements)

### DIFF
--- a/gatsby-site/src/components/locations/NationalRevenue.js
+++ b/gatsby-site/src/components/locations/NationalRevenue.js
@@ -34,6 +34,7 @@ import PRODUCTION_UNITS from '../../../static/data/production_units.yml';
 const NationalRevenue = (props) => {
 
     const REVENUE_COMMODITIES = NATIONAL_REVENUES[props.stateId].commodities;
+    let annual_revenue = NATIONAL_REVENUES[props.stateId].commodities.All[year];
 
     return (
         <section id="revenue" is="year-switcher-section" className="federal revenue">
@@ -57,8 +58,9 @@ const NationalRevenue = (props) => {
 
                 <p>For details about the laws and policies that govern how rights are awarded to companies and what they pay to extract natural resources on federal land: <Link to="/how-it-works/coal/">coal</Link>, <Link to="/how-it-works/onshore-oil-gas/">oil and gas</Link>, <Link to="/how-it-works/onshore-renewables/">renewable resources</Link>, and <Link to="/how-it-works/minerals/">hardrock minerals</Link>.</p>
 
-                <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> { year } for production or potential production of natural resources on federal land, broken down by phase of production.
+                <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> { year } for production or potential production of natural resources on federal land, broken down by phase of production. <strong>In { year }, ONRR collected a total of {utils.formatToDollarInt(annual_revenue)} in revenue.</strong>
                 </p>
+                
                 <p>
                     <Link className="data-downloads" to="/downloads/federal-revenue-by-location/" >
                         <DataAndDocs />

--- a/gatsby-site/src/components/locations/NationalRevenue.js
+++ b/gatsby-site/src/components/locations/NationalRevenue.js
@@ -34,7 +34,7 @@ import PRODUCTION_UNITS from '../../../static/data/production_units.yml';
 const NationalRevenue = (props) => {
 
     const REVENUE_COMMODITIES = NATIONAL_REVENUES[props.stateId].commodities;
-    let annual_revenue = NATIONAL_REVENUES[props.stateId].commodities.All[year];
+    let annualTotalRevenue = REVENUE_COMMODITIES && REVENUE_COMMODITIES.All && REVENUE_COMMODITIES.All[year];
 
     return (
         <section id="revenue" is="year-switcher-section" className="federal revenue">
@@ -58,7 +58,7 @@ const NationalRevenue = (props) => {
 
                 <p>For details about the laws and policies that govern how rights are awarded to companies and what they pay to extract natural resources on federal land: <Link to="/how-it-works/coal/">coal</Link>, <Link to="/how-it-works/onshore-oil-gas/">oil and gas</Link>, <Link to="/how-it-works/onshore-renewables/">renewable resources</Link>, and <Link to="/how-it-works/minerals/">hardrock minerals</Link>.</p>
 
-                <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> { year } for production or potential production of natural resources on federal land, broken down by phase of production. <strong>In { year }, ONRR collected a total of {utils.formatToDollarInt(annual_revenue)} in revenue.</strong>
+                <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> { year } for production or potential production of natural resources on federal land, broken down by phase of production. <strong>In { year }, ONRR collected a total of {utils.formatToDollarInt(annualTotalRevenue)} in revenue.</strong>
                 </p>
                 
                 <p>


### PR DESCRIPTION
Fixes #3352

[:dollar: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/add-revenue-summary/explore#revenue)

Changes proposed in this pull request:

- Adds revenue total sentence to federal revenue section intro (like disbursements section)

![revenue summary showing total revenue for current year of data](https://user-images.githubusercontent.com/32855580/49825986-a0a68c00-fd3a-11e8-880a-7a3ff897ce35.png)
