### PR TITLE
Fixes IE chevron icon bug

### DIFF
--- a/gatsby-site/src/img/icons/chevron-dn-med-white.svg
+++ b/gatsby-site/src/img/icons/chevron-dn-med-white.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="22px" height="13px" viewBox="0 0 22 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.5 (25232) - http://www.bohemiancoding.com/sketch -->
     <title>chevron-med</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>

--- a/gatsby-site/src/img/icons/chevron-down-sprite.svg
+++ b/gatsby-site/src/img/icons/chevron-down-sprite.svg
@@ -1,17 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg width="22px" height="12px" version="1.1" id="Layer_1" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="-296 379 19 72"
-	 style="enable-background:new -296 379 19 72;" xml:space="preserve">
-<title>Imported Layers Copy 2</title>
-<desc>Created with Sketch.</desc>
-<g id="Home-etc" sketch:type="MSPage">
-	<g id="Artboard-11" transform="translate(-57.000000, -53.000000)" sketch:type="MSArtboardGroup">
-		<path id="Imported-Layers-Copy-2" sketch:type="MSShapeGroup" d="M-235,447.6l5.5,5.5l5.5-5.5l0.5,0.5l-6,6l-6-6L-235,447.6z"/>
-	</g>
-</g>
-<g id="Home-etc" sketch:type="MSPage">
-	<g id="Artboard-11" transform="translate(-57.000000, -26.5)" sketch:type="MSArtboardGroup">
-		<path fill="#fff" id="Imported-Layers-Copy-2" sketch:type="MSShapeGroup" d="M-235,447.6l5.5,5.5l5.5-5.5l0.5,0.5l-6,6l-6-6L-235,447.6z"/>
-	</g>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="15px" height="7px" viewBox="0 0 35 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <defs></defs>
+    <g id="Home,-Level-2,-etc" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="chevron-med" fill="currentColor">
+            <path d="M5.99580018,16.5708807 L4.58088097,15.1559615 L13.7418426,5.99580018 L4.58088097,-3.16596176 L5.99580018,-4.58088097 L16.5708807,5.99580018" id="Imported-Layers-Copy-5" sketch:type="MSShapeGroup" transform="translate(10.575881, 5.995000) rotate(-270.000000) translate(-10.575881, -5.995000) "></path>
+        </g>
+    </g>
 </svg>

--- a/gatsby-site/src/img/icons/chevron-down-sprite.svg
+++ b/gatsby-site/src/img/icons/chevron-down-sprite.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+<svg width="22px" height="12px" version="1.1" id="Layer_1" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="-296 379 19 72"
 	 style="enable-background:new -296 379 19 72;" xml:space="preserve">
 <title>Imported Layers Copy 2</title>

--- a/gatsby-site/src/styles/elements/_forms.scss
+++ b/gatsby-site/src/styles/elements/_forms.scss
@@ -101,7 +101,7 @@ select {
 
   background-color: $gray-pale;
   background-image: url('../img/icons/chevron-down-sprite.svg');
-  background-position: 95% 54%;
+  background-position: 97% 54%;
   background-repeat: no-repeat;
   background-size: 1.5rem;
   border: 0;

--- a/gatsby-site/src/styles/elements/_forms.scss
+++ b/gatsby-site/src/styles/elements/_forms.scss
@@ -108,13 +108,13 @@ select {
   border-radius: $form-border-radius;
   color: $gray-darkest;
   font-weight: $weight-light;
-  width: 74px;
   height: 40px;
   margin-bottom: 1em;
   overflow: hidden;
   padding: 0.5em 14% 0.5em 0.8rem;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
 
   &:focus {
     box-shadow: $form-box-shadow-focus;

--- a/gatsby-site/src/styles/elements/_forms.scss
+++ b/gatsby-site/src/styles/elements/_forms.scss
@@ -101,7 +101,7 @@ select {
 
   background-color: $gray-pale;
   background-image: url('../img/icons/chevron-down-sprite.svg');
-  background-position: 95% 8%;
+  background-position: 95% 54%;
   background-repeat: no-repeat;
   background-size: 1.5rem;
   border: 0;

--- a/gatsby-site/src/styles/elements/_forms.scss
+++ b/gatsby-site/src/styles/elements/_forms.scss
@@ -108,13 +108,13 @@ select {
   border-radius: $form-border-radius;
   color: $gray-darkest;
   font-weight: $weight-light;
+  width: 74px;
   height: 40px;
   margin-bottom: 1em;
   overflow: hidden;
   padding: 0.5em 14% 0.5em 0.8rem;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
 
   &:focus {
     box-shadow: $form-box-shadow-focus;

--- a/gatsby-site/src/styles/elements/_forms.scss
+++ b/gatsby-site/src/styles/elements/_forms.scss
@@ -101,7 +101,7 @@ select {
 
   background-color: $gray-pale;
   background-image: url('../img/icons/chevron-down-sprite.svg');
-  background-position: 97% 54%;
+  background-position: 99% 54%;
   background-repeat: no-repeat;
   background-size: 1.5rem;
   border: 0;


### PR DESCRIPTION
Fixes #3446 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/ie-chevron-bug/)

Changes proposed in this pull request:

- Adds properties to SVG to attempt fix for missing icon on IE

@master12 This is a bit of a hack. Please review for a better method to fix this icon issue.
