### PR TITLE
Updates "what's new" section of homepage for release

### DIFF
--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
@@ -7,11 +7,12 @@ const WhatsNew = (props) => (
   <section className={styles.root+" slab-delta"}>
   	<div className="container-page-wrapper">
 			<h2>What's new</h2>
-			<p>In our latest release on December 6, 2018, we made the following changes:</p>
+			<p>In our latest release on December 20, 2018, we made the following changes:</p>
       <ul className="list-bullet ribbon-card-top-list">
-        <li>Launched a <Link to="/blog">blog about how we work on this site</Link></li>
-        <li>Updated monthly production data</li>
-        <li>Added documentation about <Link to="/downloads/federal-production-by-month/#monthly-totals-and-annual-totals">monthly and annual production volumes</Link></li>
+        <li>Published a <Link to="/blog">second blog post about rebuilding our homepage</Link>. This post covers how we're migrating to a new framework to build this site.</li>
+        <li>Added <Link to="/explore/#revenue">total annual revenue</Link> to our revenue summary</li>
+        <li>Updated monthly revenue data</li>
+        <li>Fixed redirect URL problems</li>
       </ul>
       <p>Review our <a href="https://github.com/ONRR/doi-extractives-data/releases">full release details</a>.</p>
 		</div>


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/whats-new-12-20-18/)

Changes proposed in this pull request:

- Updates What's new section in anticipation of release
