### PR TITLE
Fixes revenue tab redirect for "by company"

### DIFF
--- a/_how-it-works/federal-revenue-by-company/index.html
+++ b/_how-it-works/federal-revenue-by-company/index.html
@@ -1,5 +1,5 @@
 ---
 layout: redirect
 permalink: /how-it-works/federal-revenue-by-company/
-redirect_url: /how-it-works/federal-revenue-by-company/2017/
+redirect_to: /how-it-works/federal-revenue-by-company/2017/
 ---


### PR DESCRIPTION
Fixes #3507

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-company-redirect/)

Changes proposed in this pull request:

- "By company" link under Revenue tab is broken on homepage ([in dev](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/dev/))
  - This PR should fix redirect
