### PR TITLE
Adds missing state id to try to fix Idaho redirect

### DIFF
--- a/gatsby-site/gatsby-browser.js
+++ b/gatsby-site/gatsby-browser.js
@@ -21,6 +21,7 @@ const usStateIds =[
   "GA",
   "HI",
   "IA",
+  "ID",
   "IL",
   "IN",
   "KS",


### PR DESCRIPTION
Fixes #3510

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/add-missing-stateid/)

Changes proposed in this pull request:

- Adds `"ID"` to `gatsby-browser.js` to try to fix Idaho redirect issue in `dev`
