### PR TITLE
Adds sitebaseurl variable to footer link to resolve in federalist

### DIFF
--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -8,7 +8,7 @@
 
       <div class="footer-bottom-left">
 	      <p class="footer-para_callout footer-para_callout-bigger">Built in the open</p>
-	      <p class="footer-para">This site (<a href="https://github.com/onrr/doi-extractives-data/releases/{{ site.version }}" class="link-active-beta">{{ site.version }}</a>) is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">open data</a> and <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/issues/new">GitHub</a>. We write about how we work on this site on <a class="link-active-beta" href="/blog">our team's blog</a>.</p>
+	      <p class="footer-para">This site (<a href="https://github.com/onrr/doi-extractives-data/releases/{{ site.version }}" class="link-active-beta">{{ site.version }}</a>) is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">open data</a> and <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/">source code</a>. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/onrr/doi-extractives-data/issues/new">GitHub</a>. We write about how we work on this site on <a class="link-active-beta" href="{{ site.baseurl }}/blog">our team's blog</a>.</p>
 
         <p class="footer-para-small footer-para_last"><a href="https://www.doi.gov/" class="link-beta">Department of the Interior</a> | <a href="https://www.doi.gov/privacy" class="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" class="link-beta">FOIA</a> | <a href="https://www.usa.gov/" class="link-beta">USA.gov</a></p>
 


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-footer-link/)

Changes proposed in this pull request:

- This doesn't need to hold up release, but this should fix the link the preview
  - The relative link path should work in production
