### PR TITLE
Adds favicon to blog post template in addition to index

### DIFF
--- a/blog-site/src/templates/blog-post.js
+++ b/blog-site/src/templates/blog-post.js
@@ -5,6 +5,7 @@ import get from 'lodash/get'
 
 import Layout from '../components/layout'
 import { rhythm, scale } from '../utils/typography'
+import favicon from '../../static/img/favicon.ico'
 
 class BlogPostTemplate extends React.Component {
   render() {
@@ -20,6 +21,8 @@ class BlogPostTemplate extends React.Component {
           htmlAttributes={{ lang: 'en' }}
           meta={[{ name: 'description', content: siteDescription }]}
           title={`${post.frontmatter.title} | ${siteTitle}`}
+          link={[{ rel: 'shortcut icon', type: 'image/png', href: `${favicon}` }]}
+          
         >
           {/* Digital Analytics Program roll-up, see the data at https://analytics.usa.gov */}
           <script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js" id="_fed_an_ua_tag"></script>


### PR DESCRIPTION

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-favicon/blog)

Changes proposed in this pull request:

- I noticed the favicon for our blog is only displayed on the blog homepage, not each post page. This imports the favicon to the blog _post_ template in addition to index page.

![revenue data homepage tab with favicon of bison](https://user-images.githubusercontent.com/32855580/52497180-46834500-2b8a-11e9-91b0-d1f180fa434e.png)

![revenue data blog post tab with missing favicon of bison](https://user-images.githubusercontent.com/32855580/52497213-5d299c00-2b8a-11e9-81ab-1b5c980b5d58.png)

