### PR TITLE
Updates 'what's new' section for release v4.3.4

### DIFF
--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
@@ -11,7 +11,7 @@ const WhatsNew = (props) => (
         <ul className="list-bullet ribbon-card-top-list">
           <li>Updated the status of the <Link to="/how-it-works/land-and-water-conservation-fund/">Land and Water Conservation Fund</Link></li>
         </ul>  
-      <p>In our release February 7, 2019, we made the following changes:</p>  
+      <p>In our release on February 7, 2019, we made the following changes:</p>  
         <ul className="list-bullet ribbon-card-top-list">
           <li>Published a <Link to="/blog">third blog post about usability testing training</Link>. This post covers how we're expanding our capacity to perform usability testing.</li>
           <li>Updated <Link to="/downloads/federal-revenue-by-location/">fiscal year revenue data</Link> through 2018</li>

--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
@@ -7,13 +7,17 @@ const WhatsNew = (props) => (
   <section className={styles.root+" slab-delta"}>
   	<div className="container-page-wrapper">
 			<h2>What's new</h2>
-			<p>In our latest release on February 7, 2019, we made the following changes:</p>
-      <ul className="list-bullet ribbon-card-top-list">
-        <li>Published a <Link to="/blog">third blog post about usability testing training</Link>. This post covers how we're expanding our capacity to perform usability testing.</li>
-        <li>Updated <Link to="/downloads/federal-revenue-by-location/">fiscal year revenue data</Link> through 2018</li>
-        <li>Updated monthly production and revenue data</li>
-        <li>Converted <Link to="/how-it-works/revenues/#federal-lands-and-waters">revenue streams and rates</Link> image to table for accessibility</li>
-      </ul>
+			<p>In our latest release on February 14, 2019, we made the following changes:</p>
+        <ul className="list-bullet ribbon-card-top-list">
+          <li>Updated the status of the <Link to="/how-it-works/land-and-water-conservation-fund/">Land and Water Conservation Fund</Link>.</li>
+        </ul>  
+      <p>In our release February 7, 2019, we made the following changes:</p>  
+        <ul className="list-bullet ribbon-card-top-list">
+          <li>Published a <Link to="/blog">third blog post about usability testing training</Link>. This post covers how we're expanding our capacity to perform usability testing.</li>
+          <li>Updated <Link to="/downloads/federal-revenue-by-location/">fiscal year revenue data</Link> through 2018</li>
+          <li>Updated monthly production and revenue data</li>
+          <li>Converted <Link to="/how-it-works/revenues/#federal-lands-and-waters">revenue streams and rates</Link> image to table for accessibility</li>
+        </ul>
       <p>Review our <a href="https://github.com/ONRR/doi-extractives-data/releases">full release details</a>.</p>
 		</div>
 	</section>

--- a/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
+++ b/gatsby-site/src/components/sections/WhatsNew/WhatsNew.js
@@ -9,7 +9,7 @@ const WhatsNew = (props) => (
 			<h2>What's new</h2>
 			<p>In our latest release on February 14, 2019, we made the following changes:</p>
         <ul className="list-bullet ribbon-card-top-list">
-          <li>Updated the status of the <Link to="/how-it-works/land-and-water-conservation-fund/">Land and Water Conservation Fund</Link>.</li>
+          <li>Updated the status of the <Link to="/how-it-works/land-and-water-conservation-fund/">Land and Water Conservation Fund</Link></li>
         </ul>  
       <p>In our release February 7, 2019, we made the following changes:</p>  
         <ul className="list-bullet ribbon-card-top-list">


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/4-3-4-whats-new/)

Changes proposed in this pull request:

- Updates 'what's new' section for 2/14 release
  - Retains list items for 2/7 release because (1) only one update for this release and (2) we're only a week out from the last release
