### PR TITLE
Normalizes link punctuation for imperatives on how it works

### DIFF
--- a/gatsby-site/src/markdown/how-it-works/default.md
+++ b/gatsby-site/src/markdown/how-it-works/default.md
@@ -42,17 +42,17 @@ redirect_from: /how-it-works/production/
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/fossil-fuels">Fossil fuels</custom-link></h3>
             <p>Fossil fuels are our main source of electricity, and the primary fuel for powering motor vehicles and heating homes.</p>
-            <p><custom-link to="/how-it-works/fossil-fuels">Learn about oil, gas, and coal</custom-link>.</p>
+            <p><custom-link to="/how-it-works/fossil-fuels">Learn about oil, gas, and coal</custom-link></p>
           </div>
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/nonenergy-minerals">Nonenergy minerals</custom-link></h3>
             <p>Nonenergy minerals include base and precious metals, industrial metals, and gemstones, among others.</p>
-            <p><custom-link to="/how-it-works/nonenergy-minerals">Learn about nonenergy minerals</custom-link>.</p>
+            <p><custom-link to="/how-it-works/nonenergy-minerals">Learn about nonenergy minerals</custom-link></p>
           </div>
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/renewables">Renewables</custom-link></h3>
             <p>Renewable energy comes from sources that are not depleted when used. These resources include geothermal, solar, wind, water, and biomass.</p>
-            <p><custom-link to="/how-it-works/renewables">Learn about renewable energy</custom-link>.</p>
+            <p><custom-link to="/how-it-works/renewables">Learn about renewable energy</custom-link></p>
           </div>
         </div>
       </section>
@@ -62,22 +62,22 @@ redirect_from: /how-it-works/production/
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/federal-laws">Federal laws and regulations</custom-link></h3>
             <p>The legislative branch has passed many laws governing natural resource extraction on federal lands.</p>
-            <p><custom-link to="/how-it-works/federal-laws">Learn about federal laws</custom-link>.</p>
+            <p><custom-link to="/how-it-works/federal-laws">Learn about federal laws</custom-link></p>
           </div>
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/federal-reforms">Federal reforms</custom-link></h3>
             <p>The government reforms laws and regulations by enacting new legislation and proposing new rules for implementation.</p>
-            <p><custom-link to="/how-it-works/federal-reforms">Learn about reforms</custom-link>.</p>
+            <p><custom-link to="/how-it-works/federal-reforms">Learn about reforms</custom-link></p>
           </div>
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/state-laws-and-regulations/" id="state-laws-and-regulations">State laws and regulations</custom-link></h3>
             <p>State agencies create regulations and rules about natural resource extraction. Local government agencies also play a role.</p>
-            <p><custom-link to="/how-it-works/state-laws-and-regulations">Learn about state laws</custom-link>.</p>
+            <p><custom-link to="/how-it-works/state-laws-and-regulations">Learn about state laws</custom-link></p>
           </div>
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/#native-american-overview">Native American laws and regulations</custom-link></h3>
             <p>Extracting natural resources on Native American land and distributing the associated revenue involves a unique set of processes and stakeholders.</p>
-            <p><custom-link to="/how-it-works/#native-american-overview">Learn about Native American laws</custom-link>.</p>
+            <p><custom-link to="/how-it-works/#native-american-overview">Learn about Native American laws</custom-link></p>
           </div>
         </div>
       </section>
@@ -114,28 +114,28 @@ redirect_from: /how-it-works/production/
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/offshore-oil-gas">Oil and gas</custom-link><how-main-icon-oil></how-main-icon-oil></h4>
             <div>
               <p>Oil and gas (or natural gas) are fossil fuels that form underground on land and under the ocean. The U.S. is among the world's top producers of oil and gas.</p>
-              <p><custom-link to="/how-it-works/offshore-oil-gas">Learn about oil and gas</custom-link>.</p>
+              <p><custom-link to="/how-it-works/offshore-oil-gas">Learn about oil and gas</custom-link></p>
             </div>
           </div>
           <div class="landing-coal">
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/coal">Coal</custom-link><how-main-icon-coal></how-main-icon-coal></h4>
             <div>
               <p>Miners extract coal through surface and subsurface mining. Most of the coal produced on federal land in the U.S. is mined in the Powder River Basin of Wyoming.</p>
-              <p><custom-link to="/how-it-works/coal">Learn about coal</custom-link>.</p>
+              <p><custom-link to="/how-it-works/coal">Learn about coal</custom-link></p>
             </div>
           </div>
           <div class="landing-minerals">
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/minerals">Nonenergy minerals</custom-link><how-main-icon-hardrock></how-main-icon-hardrock></h4>
               <div>
               <p>Gold, copper, and iron are the main sources of nonenergy mineral revenues. The Mining Law of 1872 is the major federal law governing locatable minerals.</p>
-              <p><custom-link to="/how-it-works/minerals">Learn about nonenergy minerals</custom-link>.</p>
+              <p><custom-link to="/how-it-works/minerals">Learn about nonenergy minerals</custom-link></p>
             </div>
           </div>
           <div class="landing-renewables">
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/onshore-renewables">Renewable energy</custom-link><how-main-icon-wind></how-main-icon-wind></h4>
             <div>
               <p>Renewable energy resources include geothermal, solar, wind, biomass, and hydrokinetic energy.</p>
-              <p><custom-link to="/how-it-works/onshore-renewables">Learn about renewable energy</custom-link>.</p>
+              <p><custom-link to="/how-it-works/onshore-renewables">Learn about renewable energy</custom-link></p>
             </div>
           </div>
         </div>
@@ -144,22 +144,22 @@ redirect_from: /how-it-works/production/
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/revenues">How revenue works</custom-link></h4>
             <p>Companies pay the federal government to extract natural resources on federal lands and waters. This revenue is collected by the Office of Natural Resources Revenue.</p>
-            <p><custom-link to="/how-it-works/revenues">Learn about how revenue works</custom-link>.</p>
+            <p><custom-link to="/how-it-works/revenues">Learn about how revenue works</custom-link></p>
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/federal-revenue-by-company/2017">Federal revenue by company</custom-link></h4>
             <p>See federal non-tax revenues from natural resource extraction on federal land in 2017 by commodity, revenue type, and company.</p>
-            <p><custom-link to="/how-it-works/federal-revenue-by-company">See revenue by company</custom-link>.</p>
+            <p><custom-link to="/how-it-works/federal-revenue-by-company">See revenue by company</custom-link></p>
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/aml-reclamation-program">Abandoned Mine Land Reclamation Program</custom-link></h4>
             <p>This program uses fees from present-day coal mining companies to reclaim coal mines abandoned before 1977.</p>
-            <p><custom-link to="/how-it-works/aml-reclamation-program">Learn about the AML Reclamation Program</custom-link>.</p>
+            <p><custom-link to="/how-it-works/aml-reclamation-program">Learn about the AML Reclamation Program</custom-link></p>
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/coal-excise-tax">Coal Excise Tax</custom-link></h4>
             <p>Coal producers pay a federal excise tax, which originated in 1977 with the Black Lung Revenue Act, when they mine coal in the U.S.</p>
-            <p><custom-link to="/how-it-works/coal-excise-tax">Learn about excise tax revenue</custom-link>.</p>
+            <p><custom-link to="/how-it-works/coal-excise-tax">Learn about excise tax revenue</custom-link></p>
           </div>
         </div>
         <h3 id="disbursements" alt="Disbursements" class="h3-bar">Understanding federal disbursements</h3>
@@ -167,22 +167,22 @@ redirect_from: /how-it-works/production/
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/disbursements">How disbursements work</custom-link></h4>
             <p>The Office of Natural Resources Revenue collects revenue from natural resources extraction on federal lands and waters and distributes that revenue according to federal law. This process is called "disbursement."</p>
-            <p><custom-link to="/how-it-works/disbursements">Learn about how disbursements work</custom-link>.</p>
+            <p><custom-link to="/how-it-works/disbursements">Learn about how disbursements work</custom-link></p>
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/land-and-water-conservation-fund">Land and Water Conservation Fund</custom-link></h4>
             <p>When <glossary-term term.key="authorization">authorized</glossary-term>, the Land and Water Conservation Fund receives disbursements from offshore oil and gas revenue to support conservation, outdoor recreation, and the needs of local communities.</p>
-            <p><custom-link to="/how-it-works/land-and-water-conservation-fund">Learn about the Land and Water Conservation Fund</custom-link>.</p>
+            <p><custom-link to="/how-it-works/land-and-water-conservation-fund">Learn about the Land and Water Conservation Fund</custom-link></p>
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/historic-preservation-fund">Historic Preservation Fund</custom-link></h4>
             <p>When <glossary-term term.key="authorization">authorized</glossary-term>, the Historic Preservation Fund receives disbursements from offshore oil and gas revenue to fund the conservation of cultural and historic sites.</p>
-            <p><custom-link to="/how-it-works/historic-preservation-fund">Learn about the Historic Preservation Fund</custom-link>.</p>
+            <p><custom-link to="/how-it-works/historic-preservation-fund">Learn about the Historic Preservation Fund</custom-link></p>
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/gomesa">Gulf of Mexico Energy Security Act (GOMESA)</custom-link></h4>
             <p>The Gulf of Mexico Energy Security Act (GOMESA) created a revenue-sharing model for gulf states. Four states receive a portion of the revenue from oil and gas production in the Gulf of Mexico.</p>
-            <p><custom-link to="/how-it-works/gomesa">Learn about GOMESA</custom-link>.</p>
+            <p><custom-link to="/how-it-works/gomesa">Learn about GOMESA</custom-link></p>
           </div>
         </div>
       </section>
@@ -192,12 +192,12 @@ redirect_from: /how-it-works/production/
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/audits-and-assurances">Audits and assurances</custom-link></h3>
             <p>Data about revenue from the extractive industries is subject to a number of controls, standards, and regulations.</p>
-            <p><custom-link to="/how-it-works/audits-and-assurances">Learn about audits and assurances</custom-link>.</p>
+            <p><custom-link to="/how-it-works/audits-and-assurances">Learn about audits and assurances</custom-link></p>
           </div>
           <div>
             <h3 class="h3 landing-heading"><custom-link to="/how-it-works/reconciliation">Reconciliation</custom-link></h3>
             <p>During the reconciliation process, company reports of payments are compared to government records of revenue received.</p>
-            <p><custom-link to="/how-it-works/reconciliation">Learn about reconciliation</custom-link>.</p>
+            <p><custom-link to="/how-it-works/reconciliation">Learn about reconciliation</custom-link></p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/punctuation-cleanup/how-it-works)

Changes proposed in this pull request:

- Normalizes link punctuation on how it works to omit imperative sentence punctuation for links
