### PR TITLE
Removes static chart and replaces with table for coal excise tax revenue

### DIFF
--- a/gatsby-site/src/markdown/how-it-works/coal-excise-tax.md
+++ b/gatsby-site/src/markdown/how-it-works/coal-excise-tax.md
@@ -20,7 +20,78 @@ Coal excise tax payments are collected by the Internal Revenue Service and trans
 
 **Coal excise tax revenue**[^4]
 
-<img src="/public/img/chart-coal-excise-tax.svg" alt="Bar chart showing Coal Excise tax revenue. The chart compares Mined Underground and Surface mined.">
+<table class="article_table">
+  <thead>
+    <tr>
+      <th>Year</th>
+      <th>Surface mining</th>
+      <th>Subsurface mining</th>
+      <th>Total</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>2008</td>
+      <td>$326,258,000</td>
+      <td>$318,332,000</td>
+      <td>$644,590,000</td>
+    </tr>
+    <tr>
+      <td>2009</td>
+      <td>$324,093,000</td>
+      <td>$307,045,000</td>
+      <td>$631,138,000</td>
+    </tr>
+    <tr>
+      <td>2010</td>
+      <td>$309,170,000</td>
+      <td>$300,898,000</td>
+      <td>$610,068,000</td>
+    </tr>
+    <tr>
+      <td>2011</td>
+      <td>$324,756,000</td>
+      <td>$298,922,000</td>
+      <td>$623,678,000</td>
+    </tr>
+    <tr>
+      <td>2012</td>
+      <td>$307,383,000</td>
+      <td>$281,232,000</td>
+      <td>$588,615,000</td>
+    </tr>
+    <tr>
+      <td>2013</td>
+      <td>$280,477,000</td>
+      <td>$290,189,000</td>
+      <td>$570,661,000</td>
+    </tr>
+    <tr>
+      <td>2014</td>
+      <td>$277,469,000</td>
+      <td>$296,936,000</td>
+      <td>$574,405,000</td>
+    </tr>
+    <tr>
+      <td>2015</td>
+      <td>$270,390,000</td>
+      <td>$270,561,000</td>
+      <td>$540,951,000</td>
+    </tr>
+    <tr>
+      <td>2016</td>
+      <td>$208,428,000</td>
+      <td>$226,515,000</td>
+      <td>$434,943,000</td>
+    </tr>
+    <tr>
+      <td>2017</td>
+      <td>$207,631,000</td>
+      <td>$224,094,000</td>
+      <td>$431,725,000</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Coal excise tax rates
 


### PR DESCRIPTION
Fixes #3756

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/coal-excise-revenue-table/how-it-works/coal-excise-tax/)

Changes proposed in this pull request:

- Replaces outdated, static bar chart with updated figures in tabular format
