### PR TITLE
Changes ordered list to unordered list to avoid numeral collision

### DIFF
--- a/gatsby-site/src/markdown/downloads/disbursements.md
+++ b/gatsby-site/src/markdown/downloads/disbursements.md
@@ -57,8 +57,8 @@ _Historic Preservation Fund_ This fund helps preserve U.S. historical and archae
 
 _States_ States receive federal Outer Continental Shelf revenue in two ways:
 
-1. 27% of revenue from leases in the 8(g) Zone (the first three nautical miles of the Outer Continental Shelf) are shared with states.
-2. 37.5% of revenue from certain leases in the Gulf of Mexico are shared with Alabama, Louisiana, Mississippi, and Texas.
+- 27% of revenue from leases in the 8(g) Zone (the first three nautical miles of the Outer Continental Shelf) are shared with states.
+- 37.5% of revenue from certain leases in the Gulf of Mexico are shared with Alabama, Louisiana, Mississippi, and Texas.
 
 _Other_ Certain offshore funds are directed back to the federal agencies that administer these lands (e.g., BOEM and BSEE) to help cover the agencies’ operational costs.
 


### PR DESCRIPTION
Fixes #3767

[:dog: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/numeral-collision/downloads/disbursements/#offshore)

Changes proposed in this pull request:

- Replaces ordered list with unordered list to avoid numeral collision, and because the list isn't hierarchical (the two listed items are equal in relevance and independent from each other)
