### PR TITLE
Normalizes casing in blog post titles

### DIFF
--- a/blog-site/src/pages/usability-testing-training/index.md
+++ b/blog-site/src/pages/usability-testing-training/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Teaching Digital Skills: Learning Usability Testing by Peer Training"
+title: "Teaching digital skills: learning usability testing by peer training"
 authors:
 - Shannon McHarg
 - Maroya Faied


### PR DESCRIPTION


[:pencil: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-sentence-case/)

Changes proposed in this pull request:

- Changes our single title-case blog post title to sentence case, which we've used for all others
  - I need to write a style guide for the blog
