### PR TITLE
[WIP] Reapplies missing styles to company revenue, G1

### DIFF
--- a/gatsby-site/src/styles/blocks/explore/_regions-list.scss
+++ b/gatsby-site/src/styles/blocks/explore/_regions-list.scss
@@ -60,6 +60,10 @@
     text-align: left;
   }
 
+  .name td {
+    border-top: none;
+  }
+
   .bar_dollars {
     padding-right: $base-padding;
   }
@@ -140,6 +144,10 @@
     width: 3em;
   }
 
+  td, th .value.subtotal {
+    vertical-align: bottom;
+  }
+
   .bar { // specific to reconcilation
     width: 100px;
 
@@ -189,6 +197,12 @@
   clear: both;
   padding: 0 $base-padding;
   position: relative;
+}
+
+tbody:not(:first-child):before {
+  content: '';
+  display: block;
+  height: 2rem;
 }
 
 .region-name,


### PR DESCRIPTION
Fixes #3720
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/company-rev-styling/how-it-works/federal-revenue-by-company/2017/)

Changes proposed in this pull request:

- Reapplies company revenue styling that didn't make it to the Gatsby version of the site
