### PR TITLE
Removes left border from blog blockquotes

### DIFF
--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -47,7 +47,6 @@ h3, h4, h5 {
 
 blockquote {
   color: #545454;
-  border-left: 2px solid #545454;
   padding-left: 1em;
   font-style: italic;
 }


### PR DESCRIPTION
[:dragon: PREVIEW](https://federalist-proxy-staging.app.cloud.gov/preview/onrr/doi-extractives-data/blog-quote-border/blog)

Changes proposed in this pull request:

- Removes left border from blog blockquotes
  - In some contexts, the border would collapse against the text

## How it _should_ look
![block quote border too close to text, text is just example text and not meaningful](https://user-images.githubusercontent.com/32855580/55521011-c0d4c080-5633-11e9-81cf-e40bcd32acf9.png)

## How it often looks
![block quote without border](https://user-images.githubusercontent.com/32855580/55520998-b1ee0e00-5633-11e9-9c04-c8825c68ef45.png)

## How it will look now

![border removed from block quote, so just intro and block quote](https://user-images.githubusercontent.com/32855580/55521150-5708e680-5634-11e9-9409-9d58b82af600.png)

