### PR TITLE
Removes tax section from explore revenue

### DIFF
--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -176,14 +176,6 @@ const NationalRevenue = props => {
 
       </section>
 
-      <section>
-        <StickyHeader headerId="federal-tax-revenue" headerText='Federal tax revenue' />
-        <div>
-          <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. The federal corporate income tax rate tops out at 21%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to promote other policy goals.</p>
-          <p>Learn more about <Link to="/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</Link>.</p>
-        </div>
-      </section>
-
     </section>
   )
 }


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/pull-tax-revenue/explore#revenue)

Changes proposed in this pull request:

- Removes federal tax revenue from explore data revenue section
  - This section is outside the scope of the product vision
