### PR TITLE
Changes alignment on revenue table

### DIFF
--- a/src/components/tables/FilterTable/FilterTable.module.scss
+++ b/src/components/tables/FilterTable/FilterTable.module.scss
@@ -46,7 +46,7 @@
 	font-weight: 300;
 	padding-left: 8px;
 	padding-right: 15px;
-	
+	vertical-align: bottom;
 }
 
 .table {
@@ -89,6 +89,10 @@
 	    height: 100%;
 	    top: 0px;
 		}
+
+		td:last-of-type {
+		padding-right: 15px;
+		}
 	}
 }
 
@@ -97,9 +101,6 @@
 		background-color: _grayLight;
 		td {
 			font-weight: 600;
-		}
-		td:first-of-type {
-			text-align: right;
 		}
 	}
 }

--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -170,7 +170,7 @@ class FederalRevenue extends React.Component {
 			tableData = tableData.concat(groupByResult)
 		});
 
-		let tableTotalRow = ['Totals'];
+		let tableTotalRow = ['Total'];
 		tableTotalRow = tableTotalRow.concat(this.state.additionalColumns.map(col=>" "), this.state.filter.years.map(year => utils.formatToDollarInt(totals[year]) ))
 
 		tableData.push(tableTotalRow)


### PR DESCRIPTION
Fixes #3913

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-table-alignment/explore/revenue)

Changes proposed in this pull request:

- Vertically aligns revenue table data to bottom
