### PR TITLE
Recases and rewords selector titles in revenue table

### DIFF
--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -285,7 +285,7 @@ class FederalRevenue extends React.Component {
 					<div className={styles.filterContainer}>
 						{yearOptions &&
 							<div>
-								<div className={styles.filterLabel}>Fiscal Year(s):</div>
+								<div className={styles.filterLabel}>Fiscal year(s):</div>
 								<Select
 									multiple
 									dataSetId={REVENUES_FISCAL_YEAR}
@@ -299,7 +299,7 @@ class FederalRevenue extends React.Component {
 						}
 
 						<div>
-							<div className={styles.filterLabel}>Organize By:</div>
+							<div className={styles.filterLabel}>Organize by:</div>
 							<DropDown
 								sortType={'none'}
 						    options={Object.keys(GROUP_BY_OPTIONS)}
@@ -310,7 +310,7 @@ class FederalRevenue extends React.Component {
 						</div>
 
 						<div>
-							<div className={styles.filterLabel}>Additional Column:</div>
+							<div className={styles.filterLabel}>Add columns:</div>
 							<Select
 								multiple
 						    options={this.getAdditionalColumnOptions()}


### PR DESCRIPTION
Fixes #3904 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-table-selectors/explore/revenue)

Changes proposed in this pull request:

- Changes selector titles to sentence case and changes "Additional Columns" to "Add columns" (to match imperative sentence of "Organize by")
