### PR TITLE
Removes background and padding from intro 'slab'

### DIFF
--- a/src/pages/explore/revenue/FederalRevenue.module.scss
+++ b/src/pages/explore/revenue/FederalRevenue.module.scss
@@ -1,7 +1,3 @@
-.descriptionContainer {
-	padding: 1rem;
-}
-
 .downloadLinkContainer {
 	margin: 2rem 0;
 }

--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -262,7 +262,7 @@ class FederalRevenue extends React.Component {
 
 					<h1>Federal Revenue Data</h1>
 
-					<section className={styles.descriptionContainer+" slab-delta "}>
+					<section className={styles.descriptionContainer}>
 						<div className="ribbon-hero-description">
 							When companies lease lands to extract natural resources on federal lands and waters, they pay fees to lease the land and on the resources that are produced. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).
 						</div>


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-background/explore/revenue)

Changes proposed in this pull request:

- Removes background from opening content on revenue table
  - Background seems unnecessary; this branch removes it to sample alternative
