### PR TITLE
[WIP] Removes sticky position to restore borders in firefox

### DIFF
--- a/src/components/tables/FilterTable/FilterTable.module.scss
+++ b/src/components/tables/FilterTable/FilterTable.module.scss
@@ -8,7 +8,6 @@
 }
 
 .table {
-	border: 1px solid _grayLight;
 	th {
 	}
 	td {
@@ -52,7 +51,6 @@
 .table {
 	tr {
 		th:first-of-type {
-			position: sticky;
 			left: 0px;
 			z-index: 10;
 			span {
@@ -74,7 +72,6 @@
 	    top: 0px;
 		}
 		td:first-of-type {
-			position: sticky;
 			left: 0px;
 		}
 


### PR DESCRIPTION
Fixes #3935

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/firefox-styling/explore/data)

Changes proposed in this pull request:

- Restores table borders by eliminating `position: sticky`
- Problem: borders now mysteriously impose up the DOM
