### PR TITLE
changed default for revenue filter table organize by to Revenue type

### DIFF
--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -39,7 +39,7 @@ const TOGGLE_VALUES = {
   Month: 'month'
 }
 
-const DEFAULT_GROUP_BY_INDEX = 0;
+const DEFAULT_GROUP_BY_INDEX = 4;
 
 
 const GROUP_BY_OPTIONS = {


### PR DESCRIPTION
Fixes #3923 
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/3923-revenue-type-default/explore/revenue/)

Changes proposed in this pull request:

- Change default to Revenue type on filter table
-
-
