### PR TITLE
Clears float to reposition downloads and docs link

### DIFF
--- a/src/pages/explore/revenue/FederalRevenue.module.scss
+++ b/src/pages/explore/revenue/FederalRevenue.module.scss
@@ -1,4 +1,5 @@
 .downloadLinkContainer {
+	clear: both;
 	margin: 2rem 0;
 }
 


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/clear-float-downloads/explore/revenue)

Changes proposed in this pull request:

- My styling changes yesterday inadvertently floated the downloads and documentation link to the right
- This PR clears the float to reposition the link

## Dev
![Revenue and production descriptions with data and documentation link floated to right](https://user-images.githubusercontent.com/32855580/56228622-067a8b80-602d-11e9-8d69-4e5ea217f531.png)

## This PR
![Revenue and production descriptions with data and documentation link back to left below leasing](https://user-images.githubusercontent.com/32855580/56228490-c9ae9480-602c-11e9-94c2-4f9900ac9ac3.png)

