### PR TITLE
Revenue table firefox fixes

### DIFF
--- a/src/components/tables/FilterTable/FilterTable.module.scss
+++ b/src/components/tables/FilterTable/FilterTable.module.scss
@@ -47,14 +47,10 @@
 	tr {
 		th:first-of-type {
 			position: sticky;
+			background:white; 
+			background-clip: padding-box;
 			left: 0px;
 			z-index: 10;
-			span {
-				position: sticky;
-				background-color: white;
-				left: 0px;
-				z-index: 10;
-			}
 		}
 		th:first-of-type:after {
 	    position: absolute;

--- a/src/components/tables/FilterTable/FilterTable.module.scss
+++ b/src/components/tables/FilterTable/FilterTable.module.scss
@@ -9,15 +9,9 @@
 
 .table {
 	border: 1px solid _grayLight;
-	th {
-	}
-	td {
-		background-color: white;
-	}
 }
 
 .tableHeader th{
-	background-color: white;
 	border: 1px solid _grayLight;
 	border-bottom: 5px solid _greenLight;
 	color: _grayDarkest;
@@ -30,7 +24,6 @@
 	vertical-align: bottom;
 	z-index: 1;
 	span {
-		background-color: white;
 		z-index: 1;
 	}
 }
@@ -58,7 +51,6 @@
 			span {
 				position: sticky;
 				left: 0px;
-				background-color: white;
 				z-index: 10;
 			}
 		}
@@ -87,7 +79,7 @@
 	    content: '';
 	    width: 100%;
 	    height: 100%;
-	    top: 0px;
+		top: 0px;
 		}
 
 		td:last-of-type {

--- a/src/components/tables/FilterTable/FilterTable.module.scss
+++ b/src/components/tables/FilterTable/FilterTable.module.scss
@@ -8,11 +8,10 @@
 }
 
 .table {
-	border: 1px solid _grayLight;
+	border: none;
 }
 
-.tableHeader th{
-	border: 1px solid _grayLight;
+.tableHeader th {
 	border-bottom: 5px solid _greenLight;
 	color: _grayDarkest;
 	font-family: _baseFontFamily;
@@ -33,6 +32,8 @@
 }
 
 .tableBody td {
+	border-right: none;
+	border-left: none;
 	color: _grayDarkest;
 	font-family: _baseFontFamily;
 	font-size: 1rem;
@@ -50,6 +51,7 @@
 			z-index: 10;
 			span {
 				position: sticky;
+				background-color: white;
 				left: 0px;
 				z-index: 10;
 			}
@@ -58,8 +60,6 @@
 	    position: absolute;
 	    background-color: transparent;
 	    left: -1px;
-	    border-left: 1px solid #d3dfe6;
-	    border-right: 2px solid #d3dfe6;
 	    content: '';
 	    width: 100%;
 	    height: 100%;
@@ -70,18 +70,6 @@
 			left: 0px;
 		}
 
-		td:first-of-type:after {
-	    position: absolute;
-	    background-color: transparent;
-	    left: -1px;
-	    border-left: 1px solid #d3dfe6;
-	    border-right: 2px solid #d3dfe6;
-	    content: '';
-	    width: 100%;
-	    height: 100%;
-		top: 0px;
-		}
-
 		td:last-of-type {
 		padding-right: 15px;
 		}
@@ -90,7 +78,6 @@
 
 .table tbody{
 	tr:last-of-type {
-		background-color: _grayLight;
 		td {
 			font-weight: 600;
 		}

--- a/src/components/tables/FilterTable/FilterTable.module.scss
+++ b/src/components/tables/FilterTable/FilterTable.module.scss
@@ -67,6 +67,8 @@
 		}
 		td:first-of-type {
 			position: sticky;
+			background:white; 
+			background-clip: padding-box;
 			left: 0px;
 		}
 

--- a/src/pages/explore/revenue/FederalRevenue.module.scss
+++ b/src/pages/explore/revenue/FederalRevenue.module.scss
@@ -4,8 +4,7 @@
 }
 
 .filterContainer > div {
-	display: inline-block;
-	display: inline-grid;
+	float: left;
 	padding: 0rem 1rem;
 	width: 33%;
 }

--- a/src/pages/explore/revenue/FederalRevenue.module.scss
+++ b/src/pages/explore/revenue/FederalRevenue.module.scss
@@ -12,3 +12,13 @@
 .filterLabel {
 	margin-bottom: 0.5rem;
 }
+
+// Media queries
+
+@media only screen and (max-width: 600px) {
+	.filterContainer > div {
+		display: block;
+		padding: 0rem 1rem;
+		width: 100%;
+	}
+  }

--- a/src/pages/explore/revenue/FederalRevenue.module.scss
+++ b/src/pages/explore/revenue/FederalRevenue.module.scss
@@ -3,18 +3,12 @@
 	margin: 2rem 0;
 }
 
-.filterContainer {
-
-}
-
-
 .filterContainer > div {
 	display: inline-block;
+	display: inline-grid;
 	padding: 0rem 1rem;
 	width: 33%;
-
 }
-
 
 .filterLabel {
 	margin-bottom: 0.5rem;


### PR DESCRIPTION
Fixes #3935 and #3937 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-table-firefox/explore/revenue)

Changes proposed in this pull request:

- Fixes border styling for first column in Firefox
- Fixes alignment of select lists in Firefox
