### PR TITLE
Tweaks blog heading line height to tighten up, especially on mobile

### DIFF
--- a/blog-site/src/templates/blog-post.js
+++ b/blog-site/src/templates/blog-post.js
@@ -36,9 +36,8 @@ class BlogPostTemplate extends React.Component {
         <h1
           style={{
             ...scale(1.3),
-            lineHeight: '1.1',
+            lineHeight: '1',
             fontWeight: 800,
-            marginBottom: '1.6rem',
           }}
         >{post.frontmatter.title}</h1>
         <p
@@ -47,7 +46,7 @@ class BlogPostTemplate extends React.Component {
             display: 'block',
             color: '#768d99',
             marginBottom: rhythm(1),
-            marginTop: rhythm(-1),
+            marginTop: rhythm(-.7),
             color: '#768d99',
           }}
         >


### PR DESCRIPTION
Fixes #3820

[:stuck_out_tongue_winking_eye: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-line-height/blog)

Changes proposed in this pull request:

- Tightens line height for blog titles to remove awkward spacing between lines
