### PR TITLE
fixed duplicate revenues on home page

### DIFF
--- a/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
+++ b/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
@@ -49,11 +49,11 @@ const LAND_CLASS_CATEGORY_TO_REVENUE_CATEGORY ={
 }
 
 /* Use ES5 exports in order to be compatible with version 1.x of gatsby */
-module.exports = (node) => {
-	return createRevenueNode(node);
+module.exports = (node, type) => {
+	return createRevenueNode(node, type);
 }
 
-const createRevenueNode = (revenueData) => {
+const createRevenueNode = (revenueData, type) => {
 	const data = Object.keys(revenueData).reduce((c, k) => (c[k.toLowerCase().trim()] = revenueData[k], c), {});
 
   let revenueNode = {
@@ -70,7 +70,7 @@ const createRevenueNode = (revenueData) => {
 	  OffshoreRegion: (data[SOURCE_COLUMNS.OffshoreRegion] === "" || data[SOURCE_COLUMNS.OffshoreRegion] === undefined) ?
 	  	data[SOURCE_COLUMNS.OffshoreRegion] : "Offshore "+data[SOURCE_COLUMNS.OffshoreRegion],
 	  internal: {
-	    type: 'ResourceRevenues',
+	    type: type || 'ResourceRevenues',
 	  },
   }
 

--- a/plugins/custom-excel-transformer/gatsby-node.js
+++ b/plugins/custom-excel-transformer/gatsby-node.js
@@ -33,10 +33,10 @@ async function onCreateNode(
 				newNode = federalDisbursementsTransformer(node);
 				break;
 			case DATA_TRANSFORMER_CONSTANTS.REVENUES_MONTHLY_EXCEL:
-				newNode = revenuesTransformer(node);
+				newNode = revenuesTransformer(node, 'ResourceRevenuesMonthly');
 				break;
 			case DATA_TRANSFORMER_CONSTANTS.FEDERAL_REVENUE_FY:
-				newNode = revenuesTransformer(node);
+				newNode = revenuesTransformer(node, 'ResourceRevenuesFiscalYear');
 				break;
 		}
 

--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -303,7 +303,7 @@ class FederalRevenue extends React.Component {
 							<DropDown
 								sortType={'none'}
 						    options={Object.keys(GROUP_BY_OPTIONS)}
-						    callback={this.setGroupByFilter.bind(this)}
+						    action={this.setGroupByFilter.bind(this)}
 						    defaultOptionIndex={DEFAULT_GROUP_BY_INDEX}
 						  >
 						  </DropDown>

--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -348,7 +348,7 @@ const commodityCellRender = (data) => {
 
 export const query = graphql`
   query FederalRevenuesPageQuery {
-		allRevenues:allResourceRevenues (filter:{FiscalYear:{ne:null}}, sort: {fields: [FiscalYear], order: DESC}) {
+		allRevenues:allResourceRevenuesFiscalYear (filter:{FiscalYear:{ne:null}}, sort: {fields: [FiscalYear], order: DESC}) {
 		  data:edges {
 		    node {
 		    	id
@@ -365,7 +365,7 @@ export const query = graphql`
 		    }
 		  }
 		}
-	  allRevenuesGroupByCommodity: allResourceRevenues(
+	  allRevenuesGroupByCommodity: allResourceRevenuesFiscalYear(
 	  	filter: {
 	  		FiscalYear: {ne: null},
 	  		Commodity: {nin: [null,""]},
@@ -380,7 +380,7 @@ export const query = graphql`
 	      }
 	    }
 	  }
-	  allRevenuesGroupByState: allResourceRevenues(
+	  allRevenuesGroupByState: allResourceRevenuesFiscalYear(
 	  	filter: {
 		  	FiscalYear: {ne: null}, 
 	      State: {nin: [null,""]},
@@ -395,7 +395,7 @@ export const query = graphql`
 	      }
 	    }
 	  }
-	  allRevenuesGroupByOffshoreRegion: allResourceRevenues(
+	  allRevenuesGroupByOffshoreRegion: allResourceRevenuesFiscalYear(
 	  	filter: {
 		  	FiscalYear: {ne: null}, 
 	      OffshoreRegion: {nin: [null,""]},
@@ -410,7 +410,7 @@ export const query = graphql`
 	      }
 	    }
 	  }
-	  allRevenuesGroupByCounty: allResourceRevenues(
+	  allRevenuesGroupByCounty: allResourceRevenuesFiscalYear(
 	  	filter: {
 	  		FiscalYear: {ne: null}, 
 	      County: {nin: [null,""]},
@@ -425,7 +425,7 @@ export const query = graphql`
 	      }
 	    }
 	  }
-	  allRevenuesGroupByLandCategory: allResourceRevenues(
+	  allRevenuesGroupByLandCategory: allResourceRevenuesFiscalYear(
 	  	filter: {
 	  		FiscalYear: {ne: null}, 
 	      LandCategory: {nin: [null,""]},
@@ -440,7 +440,7 @@ export const query = graphql`
 	      }
 	    }
 	  }
-	  allRevenuesGroupByLandClass: allResourceRevenues(
+	  allRevenuesGroupByLandClass: allResourceRevenuesFiscalYear(
 	  	filter: {
 	  		FiscalYear: {ne: null}, 
 	      LandClass: {nin: [null,""]},
@@ -455,7 +455,7 @@ export const query = graphql`
 	      }
 	    }
 	  }
-	  allRevenuesGroupByRevenueType: allResourceRevenues(
+	  allRevenuesGroupByRevenueType: allResourceRevenuesFiscalYear(
 	  	filter: {
 	  		FiscalYear: {ne: null}, 
 	      RevenueType: {nin: [null,""]},
@@ -470,7 +470,7 @@ export const query = graphql`
 	      }
 	    }
 	  }
-	  allRevenuesGroupByFiscalYear: allResourceRevenues(
+	  allRevenuesGroupByFiscalYear: allResourceRevenuesFiscalYear(
 	  	filter: {
 	  		FiscalYear: {ne: null}
 	  	}, 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -277,7 +277,7 @@ export const query = graphql`
         } 
       }
     }
-    allRevenues:allResourceRevenues(
+    allRevenues:allResourceRevenuesMonthly(
       filter:{RevenueCategory:{ne: null}, Month:{ne:null}}
       sort:{fields:[RevenueDate], order: DESC}
     ) {


### PR DESCRIPTION
Fixes #3967 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-homepage-revs/)

Changes proposed in this pull request:

- added graphql types for revenues to split the various files
-
-
