### PR TITLE
Reorders 'organize by' drop down to place default at top

### DIFF
--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -39,7 +39,7 @@ const TOGGLE_VALUES = {
   Month: 'month'
 }
 
-const DEFAULT_GROUP_BY_INDEX = 4;
+const DEFAULT_GROUP_BY_INDEX = 0;
 
 
 const GROUP_BY_OPTIONS = {
@@ -113,7 +113,7 @@ class FederalRevenue extends React.Component {
 		let tableData = []; 
 
 		let totals = {}
-		// Iterate over all group by data sets asociated with this filter group by
+		// Iterate over all group by data sets associated with this filter group by
 		allDataSetGroupBy.forEach( (dataSetGroupBy, indexGroupBy) => { 
 			let groupByResult = Object.keys(dataSetGroupBy).map(name => {
 

--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -43,16 +43,16 @@ const DEFAULT_GROUP_BY_INDEX = 0;
 
 
 const GROUP_BY_OPTIONS = {
+	'Revenue type': [BY_REVENUE_TYPE],
 	'Commodity': [BY_COMMODITY], 
 	'Location': [BY_STATE, BY_OFFSHORE_REGION], 
-	'Source': [BY_LAND_CATEGORY], 
-	'Land owner': [BY_LAND_CLASS], 
-	'Revenue type': [BY_REVENUE_TYPE]
+	'Land category': [BY_LAND_CATEGORY], 
+	'Land owner': [BY_LAND_CLASS] 
 };
 const ADDITIONAL_COLUMN_OPTIONS = {
 	'Commodity': [DATA_SET_KEYS.COMMODITY],
 	'Location': ['State', DATA_SET_KEYS.OFFSHORE_REGION],
-	'Source': ['LandCategory'],
+	'Land category': ['LandCategory'],
 	'Land owner': ['LandClass'],
 	'Revenue type': ['RevenueType']
 };


### PR DESCRIPTION
[:leftwards_arrow_with_hook: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/rev-table-index/explore/revenue)

Changes proposed in this pull request:

- Resets default to 'commodity'

I'm not sure if defaulting to revenue type was intentional, but this PR reverts back to commodity if not. If the change was intentional, I think we should reorder the list (so the default option is at the top of the list).
