### PR TITLE
Fixes minor spacing issue after period in state disbursements

### DIFF
--- a/src/components/locations/SectionDisbursements.js
+++ b/src/components/locations/SectionDisbursements.js
@@ -30,7 +30,7 @@ const SectionDisbursements = props => {
     	if (usStateDisbursements && offshoreDisbursements > 0) {
       content = <div>
         <p>
-							ONRR also disburses some revenue from natural resource extraction to state governments. <strong>In { year }, ONRR disbursed {utils.formatToDollarInt(allDisbursements)} to {usStateData.title}.</strong>
+							ONRR also disburses some revenue from natural resource extraction to state governments. <strong>In { year }, ONRR disbursed {utils.formatToDollarInt(allDisbursements)} to {usStateData.title}. </strong>
 							This included revenues from both onshore and offshore extraction in or near {usStateData.title}:
         </p>
         <ul>


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/state-dis-punctuation/)

Changes proposed in this pull request:

- Adds space between sentences in state disbursements section

## Production
![missing space between sentences](https://user-images.githubusercontent.com/32855580/56543437-4efee100-6526-11e9-803c-d32be05d42f7.png)

## This PR
![space between sentences](https://user-images.githubusercontent.com/32855580/56543391-30004f00-6526-11e9-8c15-3486c237cbe4.png)
