### PR TITLE
Removes explore intro references to EIA, BLS

### DIFF
--- a/src/pages/explore/index.js
+++ b/src/pages/explore/index.js
@@ -133,7 +133,7 @@ class ExplorePage extends React.Component {
                                 </p>
                                 <p>
                                     Data on this site covers production, revenue, and disbursements for <GlossaryTerm termKey="federal land">federal lands and waters
-                                    </GlossaryTerm>, as well as nationwide production and economic impact.
+                                    </GlossaryTerm>.
                                 </p>
                             </figure>
                             <figcaption className="ribbon-card-bottom state_pages-select">


### PR DESCRIPTION
Fixes #3863

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/explore-intro/explore)

Changes proposed in this pull request:

- Removes intro references to EIA, BLS data that is no longer there
