### PR TITLE
Fixes in-page opt-in links for state revenue

### DIFF
--- a/src/components/locations/SectionOverview.js
+++ b/src/components/locations/SectionOverview.js
@@ -239,7 +239,7 @@ const OptIn = props => {
   return (
     <div>
       <p>
-          The state of {props.usStateData.title} chose to participate in an extended reporting process, so this page includes additional <a href="#state-local-revenue">state revenue</a> and <a href="#state-disbursements">disbursements</a> data, as well as contextual information about <a href="#state-governance">state governance</a> of natural resources.
+          The state of {props.usStateData.title} chose to participate in an extended reporting process, so this page includes additional <a href="#state-revenue">state revenue</a> and <a href="#state-disbursements">disbursements</a> data, as well as contextual information about <a href="#state-governance">state governance</a> of natural resources.
       </p>
       {props.optInIntroHtml &&
           <div>

--- a/src/templates/state-page.js
+++ b/src/templates/state-page.js
@@ -63,7 +63,7 @@ const NAV_ITEMS = [
         title: 'Federal revenue'
       },
       {
-        name: 'state-local-revenue',
+        name: 'state-revenue',
         title: 'State revenue'
       }
     ]


### PR DESCRIPTION
Fixes #3959

[:link: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/opt-in-revenue-link/explore/MT)

Changes proposed in this pull request:

- Fixes fragment link for opt-in state revenue