### PR TITLE
Removes reference to all production from homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -147,7 +147,7 @@ class HomePage extends React.Component {
             <Tab id="tab-production" name="Production">
               <div className={styles.tabContentContainer} >
                 <div className={styles.tabContent} >
-                  <p>The United States is among the world's top producers of oil, natural gas, and coal. The U.S. is also a global leader in renewable energy production. We have data for energy and mineral production on federal lands and waters, Native American lands, and nationwide production on all lands and waters.</p>
+                  <p>The United States is among the world's top producers of oil, natural gas, and coal. The U.S. is also a global leader in renewable energy production. We have data for energy and mineral production on federal lands and waters and Native American lands.</p>
                   <div className={styles.tabContentBottomContainer}>
                     <div>
                       <BlueButton to="/how-it-works/#production">How production works</BlueButton>


### PR DESCRIPTION
Fixes #4027

[:nerd_face: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/homepage-prod-edit/)

Changes proposed in this pull request:

- Removes reference to all lands production on homepage
