### PR TITLE
Adds links to revenue table

### DIFF
--- a/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
+++ b/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
@@ -7,7 +7,7 @@
 	margin-right: 8px;
 }
 
-.exploreDataLink a {
+a.exploreDataLink {
 	text-decoration: none;
 }
 

--- a/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
+++ b/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
@@ -7,8 +7,11 @@
 	margin-right: 8px;
 }
 
-.exploreDataLink span{
+.exploreDataLink a {
 	text-decoration: none;
+}
+
+.exploreDataLink span{
 	font-size: 1rem;
 	margin-right: 1rem;
 	vertical-align: baseline;

--- a/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
+++ b/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
@@ -8,6 +8,7 @@
 }
 
 .exploreDataLink span{
+	text-decoration: none;
 	font-size: 1rem;
 	margin-right: 1rem;
 	vertical-align: baseline;

--- a/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
+++ b/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
@@ -9,6 +9,10 @@
 
 a.exploreDataLink {
 	text-decoration: none;
+	&:hover,
+	&:active {
+	  text-decoration: underline;
+	}
 }
 
 .exploreDataLink span{

--- a/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
+++ b/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
@@ -1,6 +1,10 @@
 @value colors: "../../../../css-global/colors.scss";
 @value blue as --blue from colors;
 
+.root {
+	margin-right: 1rem;
+}
+
 .exploreDataLink svg{
 	fill: --blue;
 	vertical-align: middle;
@@ -8,5 +12,6 @@
 }
 
 .exploreDataLink span{
+	font-size: 1rem;
 	vertical-align: baseline;
 }

--- a/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
+++ b/src/components/layouts/icon-links/ExploreDataLink/ExploreDataLink.module.scss
@@ -1,10 +1,6 @@
 @value colors: "../../../../css-global/colors.scss";
 @value blue as --blue from colors;
 
-.root {
-	margin-right: 1rem;
-}
-
 .exploreDataLink svg{
 	fill: --blue;
 	vertical-align: middle;
@@ -13,5 +9,6 @@
 
 .exploreDataLink span{
 	font-size: 1rem;
+	margin-right: 1rem;
 	vertical-align: baseline;
 }

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -11,6 +11,7 @@ import GlossaryTerm from '../utils/glossary-term.js'
 import { filterTerms } from '../utils/Glossary'
 import RevenueTypeTable from '../locations/RevenueTypeTable'
 import RevenueProcessTable from '../locations/RevenueProcessTable'
+import { ExploreDataLink } from '../layouts/icon-links/ExploreDataLink'
 
 import ChartTitle from '../charts/ChartTitleCollapsible'
 
@@ -59,6 +60,8 @@ const NationalRevenue = props => {
         </p>
 
         <p>
+          <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink> 
+  
           <Link className="data-downloads" to="/downloads/federal-revenue-by-location/" >
             <DataAndDocs />
           </Link>

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -61,7 +61,7 @@ const NationalRevenue = props => {
 
         <p>
           <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink> 
-  
+          &nbsp;
           <Link className="data-downloads" to="/downloads/federal-revenue-by-location/" >
             <DataAndDocs />
           </Link>

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -108,6 +108,7 @@ const NationalRevenue = props => {
                         Non-tax revenue collected by <GlossaryTerm>ONRR</GlossaryTerm> often depends on what resources are available on federal lands and waters, as well as the laws and regulations about extraction of each resource.
             </p>
             <p>
+            <ExploreDataLink to="/explore/revenue">Revenue data in detail</ExploreDataLink>
               <Link to="/downloads/federal-revenue-by-location/" className="data-downloads">
                 <DataAndDocs />
               </Link>

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -108,7 +108,7 @@ const NationalRevenue = props => {
                         Non-tax revenue collected by <GlossaryTerm>ONRR</GlossaryTerm> often depends on what resources are available on federal lands and waters, as well as the laws and regulations about extraction of each resource.
             </p>
             <p>
-            <ExploreDataLink to="/explore/revenue">Revenue data in detail</ExploreDataLink>
+              <ExploreDataLink to="/explore/revenue">Revenue data in detail</ExploreDataLink>
               <Link to="/downloads/federal-revenue-by-location/" className="data-downloads">
                 <DataAndDocs />
               </Link>

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -60,7 +60,7 @@ const NationalRevenue = props => {
         </p>
 
         <p>
-          <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink> 
+          <ExploreDataLink className="data-downloads" to="/explore/revenue">Revenue data</ExploreDataLink> 
           <Link className="data-downloads" to="/downloads/federal-revenue-by-location/" >
             <DataAndDocs />
           </Link>

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -60,7 +60,7 @@ const NationalRevenue = props => {
         </p>
 
         <p>
-          <ExploreDataLink className="data-downloads" to="/explore/revenue">Revenue data</ExploreDataLink> 
+          <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink>
           <Link className="data-downloads" to="/downloads/federal-revenue-by-location/" >
             <DataAndDocs />
           </Link>

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -61,7 +61,6 @@ const NationalRevenue = props => {
 
         <p>
           <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink> 
-          &nbsp;
           <Link className="data-downloads" to="/downloads/federal-revenue-by-location/" >
             <DataAndDocs />
           </Link>

--- a/src/components/locations/NationalRevenue.js
+++ b/src/components/locations/NationalRevenue.js
@@ -60,7 +60,7 @@ const NationalRevenue = props => {
         </p>
 
         <p>
-          <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink>
+          <ExploreDataLink to="/explore/revenue">Revenue data in detail</ExploreDataLink>
           <Link className="data-downloads" to="/downloads/federal-revenue-by-location/" >
             <DataAndDocs />
           </Link>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -177,8 +177,8 @@ class HomePage extends React.Component {
                 <div className={styles.tabContentAside}>
                   <h5>Explore revenue data</h5>
                   <div className={styles.linkContainer}>
-                    <ExploreDataLink to="/explore/revenue">Revenue data in detail</ExploreDataLink>
-                    <ExploreDataLink to="/how-it-works/federal-revenue-by-company/">Revenue data by company</ExploreDataLink>
+                    <ExploreDataLink to="/explore/revenue">Revenue in detail</ExploreDataLink>
+                    <ExploreDataLink to="/how-it-works/federal-revenue-by-company/">Revenue by company</ExploreDataLink>
                     <DownloadDataLink to="/downloads/#revenue">Downloads and documentation</DownloadDataLink>
                   </div>
                 </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -177,8 +177,8 @@ class HomePage extends React.Component {
                 <div className={styles.tabContentAside}>
                   <h5>Explore revenue data</h5>
                   <div className={styles.linkContainer}>
-                    <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink>
-                    <ExploreDataLink to="/how-it-works/federal-revenue-by-company/">By company</ExploreDataLink>
+                    <ExploreDataLink to="/explore/revenue">Revenue data in detail</ExploreDataLink>
+                    <ExploreDataLink to="/how-it-works/federal-revenue-by-company/">Revenue data by company</ExploreDataLink>
                     <DownloadDataLink to="/downloads/#revenue">Downloads and documentation</DownloadDataLink>
                   </div>
                 </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -177,10 +177,8 @@ class HomePage extends React.Component {
                 <div className={styles.tabContentAside}>
                   <h5>Explore revenue data</h5>
                   <div className={styles.linkContainer}>
-                    <ExploreDataLink to="/explore/#revenue-phase">By production phase</ExploreDataLink>
-                    <ExploreDataLink to="/explore/#revenue-trends">By commodity</ExploreDataLink>
+                    <ExploreDataLink to="/explore/revenue">Revenue data</ExploreDataLink>
                     <ExploreDataLink to="/how-it-works/federal-revenue-by-company/">By company</ExploreDataLink>
-                    <ExploreDataLink to="/how-it-works/native-american-revenue/">Native American revenue</ExploreDataLink>
                     <DownloadDataLink to="/downloads/#revenue">Downloads and documentation</DownloadDataLink>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #3992

[:moneybag: :link: Explore data PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-table-links/explore/#revenue)

[:moneybag: :link: Homepage PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/revenue-table-links/)

Changes proposed in this pull request:

- Adds link to revenue table in explore/revenue section
