### PR TITLE
Patch 1: Applies bolding to revenue table subtext headings

### DIFF
--- a/src/pages/explore/revenue/index.js
+++ b/src/pages/explore/revenue/index.js
@@ -397,11 +397,11 @@ class FederalRevenue extends React.Component {
 							When companies lease lands to extract natural resources on federal lands and waters, they pay fees to lease the land and on the resources that are produced. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).
 						</div>
 						<div className="container-left-6">
-							Leasing<br/>
+							<strong>Leasing</strong><br/>
 							<span className="para-md">Companies bid on and lease lands and waters from the federal government. They pay a bonus when they win a lease and rent until resource production begins.</span>
 						</div>
 						<div className="container-right-6">
-							Production<br/>
+							<strong>Production</strong><br/>
 							<span className="para-md">Once enough resources are produced to pay royalties, the leaseholder pays royalties and other fees to the federal government.</span>
 						</div>
 					</section>


### PR DESCRIPTION
Fixes #4089

[:squirrel: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/5-2-1-patch-1/explore/revenue)

Changes proposed in this pull request:

- Adds bolding back to revenue table subtext
