### PR TITLE
Patch 3: Fixes revenue by company links

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -98,8 +98,8 @@ const createHtmlAstFromFrontmatterField = (createNodeField, pathPrefix, node, fi
 exports.createPages = ({ boundActionCreators, graphql }) => {
   const { createPage, createRedirect } = boundActionCreators;
 
-  createRedirect({ fromPath: '/how-it-works/federal-revenue-by-company', toPath: '/how-it-works/federal-revenue-by-company/2017', redirectInBrowser: true });
-  createRedirect({ fromPath: '/how-it-works/federal-revenue-by-company/', toPath: '/how-it-works/federal-revenue-by-company/2017', redirectInBrowser: true });
+  createRedirect({ fromPath: '/how-it-works/federal-revenue-by-company', toPath: '/how-it-works/federal-revenue-by-company/2018', redirectInBrowser: true });
+  createRedirect({ fromPath: '/how-it-works/federal-revenue-by-company/', toPath: '/how-it-works/federal-revenue-by-company/2018', redirectInBrowser: true });
 
   return Promise.all([
   	createStatePages(createPage, graphql), 

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -148,7 +148,7 @@ redirect_from: /how-it-works/production/
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/federal-revenue-by-company">Federal revenue by company</custom-link></h4>
-            <p>See federal non-tax revenues from natural resource extraction on federal land in 2017 by commodity, revenue type, and company.</p>
+            <p>See federal non-tax revenues from natural resource extraction on federal land by commodity, revenue type, and company.</p>
             <p><custom-link to="/how-it-works/federal-revenue-by-company">See revenue by company</custom-link></p>
           </div>
           <div>

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -147,7 +147,7 @@ redirect_from: /how-it-works/production/
             <p><custom-link to="/how-it-works/revenues">Learn about how revenue works</custom-link></p>
           </div>
           <div>
-            <h4 class="h3 landing-heading"><custom-link to="/how-it-works/federal-revenue-by-company/2017">Federal revenue by company</custom-link></h4>
+            <h4 class="h3 landing-heading"><custom-link to="/how-it-works/federal-revenue-by-company">Federal revenue by company</custom-link></h4>
             <p>See federal non-tax revenues from natural resource extraction on federal land in 2017 by commodity, revenue type, and company.</p>
             <p><custom-link to="/how-it-works/federal-revenue-by-company">See revenue by company</custom-link></p>
           </div>


### PR DESCRIPTION
Fixes #4092

[:squirrel: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/5-2-1-patch-3/)

Changes proposed in this pull request:

- Updates redirect for company revenue
- Generalizes company revenue links
- Removes specific 2017 reference from subtext on how-it-works
