### PR TITLE
(Slightly) boosts size of logo

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,7 +1,7 @@
 @import 'lib/font-awesome/font-awesome/variables';
 
 // Logos
-$nrrd-logo-width: 350px;
+$nrrd-logo-width: 400px;
 
 // Typography
 $weight-light: 400; // (Lato Regular) use

--- a/src/styles/blocks/_header.scss
+++ b/src/styles/blocks/_header.scss
@@ -37,7 +37,7 @@
 }
 
 .header-image {
-  max-width: 350px;
+  max-width: 400px;
   width: $nrrd-logo-width;
 
   @include respond-to(tiny-down) {

--- a/src/styles/blocks/_header.scss
+++ b/src/styles/blocks/_header.scss
@@ -40,7 +40,7 @@
   width: $nrrd-logo-width;
 
   @include respond-to(tiny-down) {
-    width: 220px;
+    width: 300px;
   }
 }
 

--- a/src/styles/blocks/_header.scss
+++ b/src/styles/blocks/_header.scss
@@ -37,7 +37,6 @@
 }
 
 .header-image {
-  max-width: 400px;
   width: $nrrd-logo-width;
 
   @include respond-to(tiny-down) {


### PR DESCRIPTION
Fixes #4096

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/wordmark-size/)

Changes proposed in this pull request:

- Increases logo size (by a little)
