### PR TITLE
Fixes logo width issue on small viewports

### DIFF
--- a/src/styles/blocks/_header.scss
+++ b/src/styles/blocks/_header.scss
@@ -40,7 +40,7 @@
   width: $nrrd-logo-width;
 
   @include respond-to(tiny-down) {
-    width: 300px;
+    width: 225px;
   }
 }
 


### PR DESCRIPTION
Fixes #<PUT ISSUE NUM HERE>

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-small-view-logo/)

Changes proposed in this pull request:

- Limits width of logo on small viewports


## Before

![iPhone screen with Natural Resources Revenue Data logo impeding navigation hamburger](https://user-images.githubusercontent.com/32855580/57878353-b0853900-77ce-11e9-8660-ae015c727e01.png)

