### PR TITLE
Minor increase in data icon size (csv, xls)

### DIFF
--- a/src/img/svg/icon-download-csv.svg
+++ b/src/img/svg/icon-download-csv.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" width="42px" height="20px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" width="45px" height="20px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 42 18" style="enable-background:new 0 0 42 14.4;" xml:space="preserve">
 <path d="M15.8,13.7h24.8c0.4,0,0.8-0.3,0.8-0.8v-11c0-0.4-0.3-0.8-0.8-0.8H15.8c-0.4,0-0.8,0.3-0.7,0.8v10.9
 	C15.1,13.3,15.4,13.7,15.8,13.7z M34,3.6l0.8,3.3C34.9,7.1,35,7.5,35,7.7c0.1-0.2,0.2-0.6,0.2-0.8l0.9-3.4h2.3l-2.3,7.9h-2.3

--- a/src/img/svg/icon-download-xls.svg
+++ b/src/img/svg/icon-download-xls.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" width="42px" height="20px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" width="45px" height="20px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 42 18" style="enable-background:new 0 0 42 16.8;" xml:space="preserve">
 <g>
 	<path d="M6.3,15.2L11,8.8c0.2-0.3,0.1-0.6-0.3-0.6H8.8C8.7,8.2,8.5,8.1,8.5,8V3.7C8.5,3.3,8.2,3,7.8,3h-4C3.4,3,3.1,3.3,3.1,3.7V8


### PR DESCRIPTION
[:chart: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/data-icon-size/downloads/federal-production/)

Changes proposed in this pull request:

- Slightly increases `csv` and `xls` icon sizes to match capital letter height for visual continuity
