### PR TITLE
Removes recruitment link in footer

### DIFF
--- a/src/components/layouts/Footer/Footer.js
+++ b/src/components/layouts/Footer/Footer.js
@@ -23,8 +23,7 @@ const Footer = ({ version }) => (
           <p className="footer-para_callout footer-para_callout-bigger">Built in the open</p>
           <p className="footer-para">This site (<a href={'https://github.com/onrr/doi-extractives-data/releases/' + version } className="link-active-beta">{ version }</a>)
         is powered by <a className="link-active-beta" href="/downloads">open data</a> and <a className="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/">source code</a>.
-        We welcome contributions and comments on <a className="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/issues/new">GitHub</a>. We write about how we work on this site on <Link to="/blog" className="link-active-beta">our team's blog</Link>.<br/>
-          <a className={styles.helpWanted} href="https://docs.google.com/forms/d/e/1FAIpQLSe5fTZq_SCrid9N48Bh2DJ-WzHfYvo75-En6g7f9iaIK6EGiQ/viewform">Help make this site better.<span style={{ paddingLeft: '15px', verticalAlign: 'middle' }}><BullhornIcon viewBox="0 -15 100 100" width="25px" height="25px"/></span></a></p>
+        We welcome contributions and comments on <a className="link-active-beta" href="https://github.com/ONRR/doi-extractives-data/issues/new">GitHub</a>. We write about how we work on this site on <Link to="/blog" className="link-active-beta">our team's blog</Link>.</p>
 
           <p className="footer-para-small footer-para_last"><a href="https://www.doi.gov/" className="link-beta">Department of the Interior</a> | <a href="https://www.doi.gov/privacy" className="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" className="link-beta">FOIA</a> | <a href="https://www.usa.gov/" className="link-beta">USA.gov</a></p>
 


### PR DESCRIPTION
Fixes #4049

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/remove-helpus-link/)

Changes proposed in this pull request:

- Removes user-research recruitment link from footer
