### PR TITLE
Spacing in megachart

### DIFF
--- a/src/components/locations/RevenueProcessTable.js
+++ b/src/components/locations/RevenueProcessTable.js
@@ -41,7 +41,7 @@ const RevenueTypeTableRow = props => {
     <tr>
 		    <th scope="row" data-value={props.commodityData.All[props.year]} name={'#revenue-' + utils.formatToSlug(props.commodityName)} className="table-arrow_box-subheader">
 		      <strong>{ props.commodityName }</strong><br/>
-		      <strong className="table-arrow_box-subheader-value">{ utils.formatToDollarInt(props.commodityData.All[props.year]) }</strong>
+		      <strong className="table-arrow_box-subheader-value"> { utils.formatToDollarInt(props.commodityData.All[props.year]) }</strong>
 		    </th>
 		  	{
 		  		revenueTypeNames.map((revenueTypeName, index) => {

--- a/src/components/locations/RevenueProcessTable.js
+++ b/src/components/locations/RevenueProcessTable.js
@@ -183,25 +183,25 @@ const RevenueProcessTable = props => {
 			  	}
 			  	{ valuesRoyalties.Oil > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">Oil</strong>
+				  		<strong className="text-header text-header-first">Oil </strong>
 				  		{ utils.formatToDollarInt(valuesRoyalties.Oil)}
 				  	</span>
 			  	}
 			  	{ valuesRoyalties.Gas > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">Gas</strong>
+				  		<strong className="text-header text-header-first">Gas </strong>
 				  		{ utils.formatToDollarInt(valuesRoyalties.Gas)}
 				  	</span>
 			  	}
 			  	{ valuesRoyalties.NGL > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">NGL</strong>
+				  		<strong className="text-header text-header-first">NGL </strong>
 				  		{ utils.formatToDollarInt(valuesRoyalties.NGL)}
 				  	</span>
 			  	}
 			  	{ valuesRoyalties.OilShale > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">OilShale</strong>
+				  		<strong className="text-header text-header-first">OilShale </strong>
 				  		{ Ututilsils.formatToDollarInt(valuesRoyalties.OilShale)}
 				  	</span>
 			  	}

--- a/src/components/locations/RevenueTypeTable.js
+++ b/src/components/locations/RevenueTypeTable.js
@@ -57,7 +57,7 @@ const RevenueTypeTableRow = props => {
 			  							<span className="table-arrow_box-asterisk">
 			  								* Includes revenues not tied to specific commo&shy;dities
 			  								({ utils.formatToDollarInt(NATIONAL_REVENUES_INSPECTION_FEES[props.year]) } in inspection fees, 
-			  								{ utils.formatToDollarInt(NATIONAL_REVENUES_CIVIL_PENALTIES[props.year]) } in civil penalties,
+			  								{' ' +  utils.formatToDollarInt(NATIONAL_REVENUES_CIVIL_PENALTIES[props.year]) } in civil penalties,
 			  								and { utils.formatToDollarInt(NATIONAL_REVENUES_OTHER_REVENUES[props.year]) } in other revenue).
 			  							</span>
 		  							</div>
@@ -182,25 +182,25 @@ const RevenueTypeTable = props => {
 			  	}
 			  	{ valuesRoyalties.Oil > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">Oil</strong>
+				  		<strong className="text-header text-header-first">Oil </strong>
 				  		{ utils.formatToDollarInt(valuesRoyalties.Oil)}
 				  	</span>
 			  	}
 			  	{ valuesRoyalties.Gas > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">Gas</strong>
+				  		<strong className="text-header text-header-first">Gas </strong>
 				  		{ utils.formatToDollarInt(valuesRoyalties.Gas)}
 				  	</span>
 			  	}
 			  	{ valuesRoyalties.NGL > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">NGL</strong>
+				  		<strong className="text-header text-header-first">NGL </strong>
 				  		{ utils.formatToDollarInt(valuesRoyalties.NGL)}
 				  	</span>
 			  	}
 			  	{ valuesRoyalties.OilShale > 0 &&
 				  	<span className="text table-arrow_box-subheader-value">
-				  		<strong className="text-header text-header-first">OilShale</strong>
+				  		<strong className="text-header text-header-first">OilShale </strong>
 				  		{ utils.formatToDollarInt(valuesRoyalties.OilShale)}
 				  	</span>
 			  	}

--- a/src/components/locations/RevenueTypeTable.js
+++ b/src/components/locations/RevenueTypeTable.js
@@ -40,7 +40,7 @@ const RevenueTypeTableRow = props => {
     <tr>
 		    <th scope="row" data-value={props.commodityData.All[props.year]} name={'#revenue-' + utils.formatToSlug(props.commodityName)} className="table-arrow_box-subheader">
 		      <strong>{ props.commodityName }</strong><br/>
-		      <strong className="table-arrow_box-subheader-value">{ utils.formatToDollarInt(props.commodityData.All[props.year]) }</strong>
+		      <strong className="table-arrow_box-subheader-value"> { utils.formatToDollarInt(props.commodityData.All[props.year]) }</strong>
 		    </th>
 		  	{
 		  		revenueTypeNames.map((revenueTypeName, index) => {
@@ -56,7 +56,7 @@ const RevenueTypeTableRow = props => {
 		  								<br/>
 			  							<span className="table-arrow_box-asterisk">
 			  								* Includes revenues not tied to specific commo&shy;dities
-			  								({ utils.formatToDollarInt(NATIONAL_REVENUES_INSPECTION_FEES[props.year]) } in inspection fees,
+			  								({ utils.formatToDollarInt(NATIONAL_REVENUES_INSPECTION_FEES[props.year]) } in inspection fees, 
 			  								{ utils.formatToDollarInt(NATIONAL_REVENUES_CIVIL_PENALTIES[props.year]) } in civil penalties,
 			  								and { utils.formatToDollarInt(NATIONAL_REVENUES_OTHER_REVENUES[props.year]) } in other revenue).
 			  							</span>


### PR DESCRIPTION
Fixes #4112

[:bird: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/spacing-in-mega/explore/#revenue)

Changes proposed in this pull request:

- Fixes spacing problems between static content and data variables

![table showing oil, gas, and ngl with no space between the text and the numbers that follow](https://user-images.githubusercontent.com/32855580/59375908-f7018100-8d03-11e9-9da3-fa03a9ea6ecb.png)

![expanation of revenues not tied to specific commodities for inspection fees, civil penalties, and other revenue where text collides with data numbers](https://user-images.githubusercontent.com/32855580/59375916-fe288f00-8d03-11e9-869b-1b62ec393e5a.png)

