### PR TITLE
Styling for revenue trends

### DIFF
--- a/src/components/sections/RevenueTrends/RevenueTrends.module.scss
+++ b/src/components/sections/RevenueTrends/RevenueTrends.module.scss
@@ -8,11 +8,12 @@
 .title {
 	font-size: 1.125rem;
 	font-weight: 600;
-	margin-bottom: 0px;
+	margin-bottom: 5px;
 }
 
 .revenueTable {
 		border: none !important;
+		margin: 1rem 0 0 0;
 		th, td {
 			border: none !important;
 			font-size: 0.875rem;
@@ -20,7 +21,17 @@
 			white-space: nowrap !important;
 			width: 100%;
 			margin-top: 0.5rem;
-		} 
+		}
+		th {
+			font-weight: bold;
+		}
+		tr:first-of-type td {
+			padding-top: 5px !important;
+		}
+		tr:nth-of-type(2n) td {
+			padding-bottom: 7px !important;
+			font-weight: 300;
+		}
 }
 
 .alignRight {


### PR DESCRIPTION
[:chart: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/trends-stylz/)

I tweaked the styling for revenue trends. The content is currently compacted, with little space to distinguish the content. This PR adds padding between the revenue types and uses font weight to support hierarchy.

Changes proposed in this pull request:

- Adds padding between revenue types
- Adds hierarchy of font weight for readability
- Adds font weight to table header styling

## Current
![Layout of homepage with revenue trends and overview, showing dollar amounts for royalties, bonuses, rents, other revenues, and total revenues](https://user-images.githubusercontent.com/32855580/59542012-b5fe9d80-8eb8-11e9-81ed-49ff1cc0d8f2.png)

## This PR
![Layout of homepage with revenue trends and overview, showing dollar amounts for royalties, bonuses, rents, other revenues, and total revenues with more space between rows and lighter font weight for sub content](https://user-images.githubusercontent.com/32855580/59542063-e8a89600-8eb8-11e9-91f8-31509cccd727.png)

