### PR TITLE
Removes redundant title tag from path in state-map and CountyMap

### DIFF
--- a/builds/maps/bin/state-map.js
+++ b/builds/maps/bin/state-map.js
@@ -167,11 +167,7 @@ var render = function(objects, done) {
               return 'county-' + zerofill(d.id, 5);
             })
             .attr('class', 'county feature')
-            .attr('d', path)
-            .append('title')
-              .text(function(d) {
-                return d.properties.name;
-              });
+            .attr('d', path);
     }
 
     // TODO: land ownership

--- a/src/components/maps/CountyMap.js
+++ b/src/components/maps/CountyMap.js
@@ -135,7 +135,6 @@ const CountyMap = props => {
 			                            data-value={countyData[1].products[props.productKey].volume[props.year]}
 			                            data-year-values={JSON.stringify(countyData[1].products[props.productKey].volume)}
 			                            >
-			                            <title>{ countyData[1].name }</title>
 			                            <use xlinkHref={usStateSVG + '#county-' + countyData[0]}></use>
 			                        </g>
 			                    )

--- a/src/components/maps/CountyMap.js
+++ b/src/components/maps/CountyMap.js
@@ -113,7 +113,7 @@ const CountyMap = props => {
 			                            data-value={countyData[1].products[props.productKey].volume[props.year]}
 			                            data-year-values={JSON.stringify(countyData[1].products[props.productKey].volume)}
 			                            >
-			                            <title>{ countyData[1].name }</title>
+			                            <data>{ countyData[1].name }</data>
 			                            <use xlinkHref={usStateSVG + '#county-' + countyData[0]}></use>
 			                        </g>
 			                    )


### PR DESCRIPTION
Fixes #3191

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/duplicate-tips/explore/NV/#federal-production)

Changes proposed in this pull request:

- Removes duplicate `title` on `path` in `state-map.js`
- Changes `title` element to `data` element for `<title>{ countyData[1].name }</title>` in `CountyMap.js`
- Eliminates redundant tooltips

## Current
![Map of Nevada showing Eureka County with two tooltips showing the name of the county overlaid on top of each other](https://user-images.githubusercontent.com/32855580/59809738-ca76d780-92b6-11e9-9b4c-814795ea177d.png)

## This PR
![Map of Nevada showing Eureka County with two tooltips showing the name of the county in single tooltip](https://user-images.githubusercontent.com/32855580/59862866-6bf23d80-9338-11e9-9f69-5105119a5541.png)
