### PR TITLE
4024 remove state GDP links

### DIFF
--- a/src/components/locations/SectionOverview.js
+++ b/src/components/locations/SectionOverview.js
@@ -156,7 +156,7 @@ const KeyGDPJobs = props => {
             Natural resource extraction varies widely from state to state.{' '}
       {(usStateGDP && usStateGDP[year] && usStateGDP[year].dollars > 0)
         ? <span>
-                    In {props.usStateData.title}, extractive industries accounted for <a href="#gdp">{ utils.round(usStateGDP[year].percent, 1) }% of gross domestic product</a> (GDP) in {year}
+                    In {props.usStateData.title}, extractive industries accounted for { utils.round(usStateGDP[year].percent, 1) }% of gross domestic product (GDP) in {year}
           { usStateJobs[year] && (usStateJobs[year].percent > 2) &&
                         <span>
                             , and jobs in the extractive industries made up <a href="#employment">{utils.round(usStateJobs[year].percent, 1)}% of statewide employment</a>

--- a/src/components/locations/SectionOverview.js
+++ b/src/components/locations/SectionOverview.js
@@ -159,7 +159,7 @@ const KeyGDPJobs = props => {
                     In {props.usStateData.title}, extractive industries accounted for { utils.round(usStateGDP[year].percent, 1) }% of gross domestic product (GDP) in {year}
           { usStateJobs[year] && (usStateJobs[year].percent > 2) &&
                         <span>
-                            , and jobs in the extractive industries made up <a href="#employment">{utils.round(usStateJobs[year].percent, 1)}% of statewide employment</a>
+                            , and jobs in the extractive industries made up {utils.round(usStateJobs[year].percent, 1)}% of statewide employment
                         </span>
           }
                     .


### PR DESCRIPTION
Fixes #4024

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/remove-gdp/explore/TX/)

Changes proposed in this pull request:

- Removed a href Attribute from gdp in SectionOverview.js
