### PR TITLE
Makes alt text more specific

### DIFF
--- a/blog-site/src/pages/open-data-useful/index.md
+++ b/blog-site/src/pages/open-data-useful/index.md
@@ -29,27 +29,27 @@ Now our core focus has shifted from meeting specific EITI requirements to meetin
 
 As I’ve talked with more and more users, I’ve discovered they differ primarily in two areas: how they find data on the site and how they use the data after they find it. They fall into four primary user types: Question Answerers, Agenda Supporters, Storytellers, and Domain Learners. The unlettered circles in the image below represent users we’ve interviewed over the last year or so. The ones with letters represent the summarized user types.
 
-![Visual summary of where participants across studies have fallen](./AllUsers.PNG)
+![user types mapped on one triangle representing known questions, system understanding, and exploration and another triangle representing providing an answer, presenting data, and making a decision](./AllUsers.PNG)
 User type summary of where participants across studies have fallen.
 
 Question Answerers generally come to the site with a known question and need to provide the answer to that question directly to the person who asked it. A large portion are internal ONRR analysts who field questions from external audiences and previously used the decommissioned internal site. Congressional staffers also often fall into this user type.
 
-![Visual summary of question answerer participants](./QuestionAnswerers.PNG)
+![Visual summary of question answerer participants, with the majority located close to known question for finding data on the site and close to provide an answer for usage of the data, defined as someone else is asking them for information or they have a specific question or number they need](./QuestionAnswerers.PNG)
 Question answers
 
 Agenda Supporters are people who work for organizations, such as non-governmental organizations (NGOs), or are political appointees or congressional staffers who are committed to a cause. They look for data to support their cause and may revise their agenda based on what they find from exploring the data. They generally want to take action based on their agenda.
 
-![Visual summary of agenda supporter participants](./AgendaSupporters.PNG)
+![Visual summary of agenda supporter participants, with the majority of participants located between known question and exploration for finding data on the site, closer to known question and between find an answer and present data, closer to present data, for usage of the data, defined as someone who is committed to a cause and looking for data to support that cause](./AgendaSupporters.PNG)
 Agenda supporters
 
 Storytellers are often journalists and academics who want to understand what is happening and learn from the data whether there’s a story to tell. They also come to the site when they already have a story in mind and need a number or want to flesh it out with information from multiple sources. Their primary goal is to tell the story in a compelling and factual way.
 
-![Visual summary of storyteller participants](./Storytellers.PNG)
+![Visual summary of storyteller participants, with the majority of participants located close to exploration for finding data on the site and close to present data for usage of the data, defined as someone who is looking for the data to tell them a story that they can then share with others](./Storytellers.PNG)
 Storytellers
 
 Domain Learners are engaged at a higher level and want to understand the bigger picture. They are in charge of a domain, such as a federal government agency, state, county, or Native American tribe and want to know what is going on in that domain. They need to make decisions and answer questions based on what they see in the data.
 
-![Visual summary of domain learner participants](./DomainLearners.PNG)
+![Visual summary of domain learner participants, with the majority of participants located between system understanding and known question, closer to system understanding, for finding data on the site and closest to make a decision, but also close to provide an answer and present data, for usage of the data, defined as someone who seeks to understand the whole picture for the domain they oversee](./DomainLearners.PNG)
 Domain learners
 
 We now ask every user we talk with about their behaviors and have been refining our understanding over time. You can see that we moved the Storyteller and Domain Leaner locations on the triangles as we saw the real users clustering in places we didn’t expect.


### PR DESCRIPTION

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/triangle-alt-text/blog)

Changes proposed in this pull request:

- Makes the alt text on the triangle images more specific to make it easier for users to understand
