### PR TITLE
Adds copy for no search results

### DIFF
--- a/src/pages/search-results/index.js
+++ b/src/pages/search-results/index.js
@@ -56,7 +56,7 @@ const SearchResults = () => {
                     results.map((item, index) => {
                       return <li key={ index }><Link to={ item.path }>{ item.title }</Link></li>
                     }
-                    ) : <p><strong>Sorry, we didn't find any results for your search.</strong></p>
+                    ) : <p><strong>We didn't find any results for your search.</strong> You might want to try searching for <GlossaryTerm termKey={queryString}>{queryString}</GlossaryTerm> in our glossary.</p>
                   }
                 </ul>
               </article>  

--- a/src/pages/search-results/index.js
+++ b/src/pages/search-results/index.js
@@ -56,7 +56,7 @@ const SearchResults = () => {
                     results.map((item, index) => {
                       return <li key={ index }><Link to={ item.path }>{ item.title }</Link></li>
                     }
-                    ) : <li className="list-unstyled"><strong>We didn't find any results for your search.</strong> You might want to try searching for <GlossaryTerm termKey={queryString}>{queryString}</GlossaryTerm> in our glossary.</li>
+                    ) : <p><strong>We didn't find any results for your search.</strong> You might want to try searching for <GlossaryTerm termKey={queryString}>{queryString}</GlossaryTerm> in our glossary.</p>
                   }
                 </ul>
               </article>  

--- a/src/pages/search-results/index.js
+++ b/src/pages/search-results/index.js
@@ -56,7 +56,7 @@ const SearchResults = () => {
                     results.map((item, index) => {
                       return <li key={ index }><Link to={ item.path }>{ item.title }</Link></li>
                     }
-                    ) : <p><strong>We didn't find any results for your search.</strong> You might want to try searching for <GlossaryTerm termKey={queryString}>{queryString}</GlossaryTerm> in our glossary.</p>
+                    ) : <li className="list-unstyled"><strong>We didn't find any results for your search.</strong> You might want to try searching for <GlossaryTerm termKey={queryString}>{queryString}</GlossaryTerm> in our glossary.</li>
                   }
                 </ul>
               </article>  

--- a/src/pages/search-results/index.js
+++ b/src/pages/search-results/index.js
@@ -49,14 +49,14 @@ const SearchResults = () => {
             <div className="container-left-8">
               <h1 id="introduction">Search Results</h1>
             </div>
-            <div class="search-results-container">
-              <article class="search-results-container">
+            <div className="search-results-container">
+              <article className="search-results-container">
                 <ul>
-                  {results &&
+                  {results.length > 0 ?
                     results.map((item, index) => {
                       return <li key={ index }><Link to={ item.path }>{ item.title }</Link></li>
                     }
-                    )
+                    ) : <p><strong>Sorry, we didn't find any results for your search.</strong></p>
                   }
                 </ul>
               </article>  


### PR DESCRIPTION
Fixes #4256

[🔍 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/search-no-results/)

Changes proposed in this pull request:

- Adds conditional to produce copy indicating no search results yielded
- Adds a link to glossary for secondary search

This PR adds an explanation for no search results, but it also adds the search term as a link to open the glossary with that term. This is not necessary, but it could be useful in such cases as "BLM," which currently doesn't produce any search results, but for which we have a glossary term entry:

![We didn't find any results for your search. You might want to try searching for blm in our glossary, with open glossary panel with blm defined as The Bureau of Land Management (BLM) is part of the U.S. Department of the Interior, and manages exploration, development, and production of natural resources on federal lands](https://user-images.githubusercontent.com/32855580/61329837-20b23a00-a7d3-11e9-89ad-7e2faeb4abfe.png)

Alternatively, we could simply produce the line:

> We didn't find any results for `{ queryString }`.

which, in this case, would resolve to:

> We didn't find any results for blm.