### PR TITLE
Adds responsive styling for blog titles on mobile

### DIFF
--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -35,6 +35,11 @@
   text-align: center;
 }
 
+.post-heading {
+  font-size: 2.5rem;
+  font-weight: 800;
+}
+
 p + h2 {
   margin-bottom: .7rem;
 }
@@ -146,5 +151,8 @@ a:hover {
   .masthead {
     font-size: 1.7rem;
     line-height: 1.9rem;
+  }
+  .post-heading {
+    font-size: 1.7rem;
   }
 }

--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -37,6 +37,7 @@
 
 .post-heading {
   font-size: 2.5rem;
+  line-height: 1;
   font-weight: 800;
 }
 

--- a/blog-site/src/templates/blog-post.js
+++ b/blog-site/src/templates/blog-post.js
@@ -33,13 +33,7 @@ class BlogPostTemplate extends React.Component {
           }
         </Helmet>
 
-        <h1
-          style={{
-            ...scale(1.3),
-            lineHeight: '1',
-            fontWeight: 800,
-          }}
-        >{post.frontmatter.title}</h1>
+        <h1 className="post-heading">{post.frontmatter.title}</h1>
         <p
           style={{
             ...scale(-1 / 5),


### PR DESCRIPTION

[📝 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-mobile-heading/blog/journey-mapping/)

Changes proposed in this pull request:

Our blog post headings are awkwardly large on mobile, causing unfortunate wrapping on smaller viewports. This PR adds styling to reduce the blog heading on small viewports.

## Current
![Heading title of Journey maps as communication tools with communication wrapping on two lines](https://user-images.githubusercontent.com/32855580/61416785-c637dd00-a8a9-11e9-89c1-0e2414dab7e2.png)

## This PR
![Heading title of Journey maps as communication tools with no breaking of parts of words to new lines](https://user-images.githubusercontent.com/32855580/61416807-dbad0700-a8a9-11e9-8228-c4de0c19ce8b.png)


