### PR TITLE
Moves basic natural resources info to archive

### DIFF
--- a/src/markdown/archive/default.md
+++ b/src/markdown/archive/default.md
@@ -68,6 +68,26 @@ tag:
         </div>
       </section>
       <section class="container">
+        <h2 id="resources" alt="Natural resources" class="h2-bar">About natural resources</h2>
+        <div class="container landing-section">
+          <div>
+            <h3 class="h3 landing-heading"><custom-link to="/how-it-works/fossil-fuels">Fossil fuels</custom-link></h3>
+            <p>Fossil fuels are our main source of electricity, and the primary fuel for powering motor vehicles and heating homes.</p>
+            <p><custom-link to="/how-it-works/fossil-fuels">Learn about oil, gas, and coal</custom-link></p>
+          </div>
+          <div>
+            <h3 class="h3 landing-heading"><custom-link to="/how-it-works/nonenergy-minerals">Nonenergy minerals</custom-link></h3>
+            <p>Nonenergy minerals include base and precious metals, industrial metals, and gemstones, among others.</p>
+            <p><custom-link to="/how-it-works/nonenergy-minerals">Learn about nonenergy minerals</custom-link></p>
+          </div>
+          <div>
+            <h3 class="h3 landing-heading"><custom-link to="/how-it-works/renewables">Renewables</custom-link></h3>
+            <p>Renewable energy comes from sources that are not depleted when used. These resources include geothermal, solar, wind, water, and biomass.</p>
+            <p><custom-link to="/how-it-works/renewables">Learn about renewable energy</custom-link></p>
+          </div>
+        </div>
+      </section>
+      <section class="container">
         <h2 id="audits-reconciliation" class="h2-bar">Audits and reconciliation</h2>
         <div class="container landing-section">
           <div>

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -37,26 +37,6 @@ redirect_from: /how-it-works/production/
         </div>
       </section>
       <section class="container">
-        <h2 id="resources" alt="Natural resources" class="h2-bar">What natural resources are extracted in the U.S.?</h2>
-        <div class="container landing-section">
-          <div>
-            <h3 class="h3 landing-heading"><custom-link to="/how-it-works/fossil-fuels">Fossil fuels</custom-link></h3>
-            <p>Fossil fuels are our main source of electricity, and the primary fuel for powering motor vehicles and heating homes.</p>
-            <p><custom-link to="/how-it-works/fossil-fuels">Learn about oil, gas, and coal</custom-link></p>
-          </div>
-          <div>
-            <h3 class="h3 landing-heading"><custom-link to="/how-it-works/nonenergy-minerals">Nonenergy minerals</custom-link></h3>
-            <p>Nonenergy minerals include base and precious metals, industrial metals, and gemstones, among others.</p>
-            <p><custom-link to="/how-it-works/nonenergy-minerals">Learn about nonenergy minerals</custom-link></p>
-          </div>
-          <div>
-            <h3 class="h3 landing-heading"><custom-link to="/how-it-works/renewables">Renewables</custom-link></h3>
-            <p>Renewable energy comes from sources that are not depleted when used. These resources include geothermal, solar, wind, water, and biomass.</p>
-            <p><custom-link to="/how-it-works/renewables">Learn about renewable energy</custom-link></p>
-          </div>
-        </div>
-      </section>
-      <section class="container">
         <h2 id="laws" alt="Laws and regulations" class="h2-bar">What laws and regulations govern natural resource extraction in the U.S.?</h2>
         <div class="container landing-section">
           <div>

--- a/src/markdown/how-it-works/fossil-fuels.md
+++ b/src/markdown/how-it-works/fossil-fuels.md
@@ -14,6 +14,8 @@ tag:
 <custom-link to="/how-it-works/" className="breadcrumb link-charlie">How it works</custom-link> /
 # Fossil fuels
 
+<archive-banner></archive-banner>
+
 > Fossil fuels are our main source of electricity and the primary fuel for powering motor vehicles and heating homes. Fossil fuels are used to make many products. Through natural processes over hundreds of millions of years, plant and animal matter becomes energy resources in the form of oil, gas, and coal. While fossil fuels are abundant, they are not renewable. [Explore production data.](/explore/#production)
 
 ### Oil

--- a/src/markdown/how-it-works/nonenergy-minerals.md
+++ b/src/markdown/how-it-works/nonenergy-minerals.md
@@ -19,6 +19,8 @@ tag:
 <custom-link to="/how-it-works/" className="breadcrumb link-charlie">How it works</custom-link> /
 # Nonenergy minerals
 
+<archive-banner></archive-banner>
+
 > Nonenergy minerals include base and precious metals, industrial metals, and gemstones, among others. Gold, copper, iron, and zinc are the principal contributors to metal mine production.
 
 ### Gold

--- a/src/markdown/how-it-works/renewables.md
+++ b/src/markdown/how-it-works/renewables.md
@@ -15,6 +15,8 @@ tag:
 <custom-link to="/how-it-works/" className="breadcrumb link-charlie">How it works</custom-link> /
 # Renewables
 
+<archive-banner></archive-banner>
+
 > Renewable energy comes from sources that are not depleted when used. These resources include geothermal, solar, wind, water, and biomass. All are growing sources of environmentally sustainable energy to meet the country’s electricity needs. [Explore production data](/explore/#production).
 
 ## Geothermal energy


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/move-resources-archive/archive)

Changes proposed in this pull request:

- After noticing some confusion about the differences and relationship between the natural resources section and "diving" section of how-it-works, this PR moves the basic natural resources info to the archive. 

- Basic info on fossil fuels, renewables, and nonenergy minerals can be found across the web, and we provide no specific value-add by having here among our other, DOI-specific content.
