### PR TITLE
Fixes top products bug on state template

### DIFF
--- a/src/components/locations/SectionOverview.js
+++ b/src/components/locations/SectionOverview.js
@@ -203,7 +203,7 @@ const KeyAllProduction = props => {
 
   return (
     <div>
-      {productsRankedOne &&
+      {productsRankedOne.length > 0 &&
                 <div>
                   <p>{props.usStateData.title} leads the nation in production of:</p>
                   {getProductListItems()}


### PR DESCRIPTION
Fixes #4399

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-state-top-prods/explore/MT)

Changes proposed in this pull request:

- A line of text is being rendered on state pages even if there is no data associated (top products). This change will only print text if the data exists.

![Oregon leads the nation in the production of, followed by no content](https://user-images.githubusercontent.com/32855580/62555753-be2be700-b830-11e9-8f69-3fe28abb4845.png)

![No content for top products on Oregon state intro page](https://user-images.githubusercontent.com/32855580/62555839-e4518700-b830-11e9-9446-7a9e8f30f595.png)

