### PR TITLE
Fixes spacing issues on state template

### DIFF
--- a/src/components/locations/SectionOverview.js
+++ b/src/components/locations/SectionOverview.js
@@ -225,9 +225,7 @@ const OptIn = props => {
   return (
     <div>
       <p>
-        The state of {props.usStateData.title} chose to participate in an extended reporting process, so this page includes additional
-        <a href="#state-revenue">state revenue</a> and <a href="#state-disbursements">disbursements</a> data, as well as contextual information about
-        <a href="#state-governance">state governance</a> of natural resources.
+        The state of {props.usStateData.title} chose to participate in an extended reporting process, so this page includes additional <a href="#state-revenue">state revenue</a> and <a href="#state-disbursements">disbursements</a> data, as well as contextual information about <a href="#state-governance">state governance</a> of natural resources.
       </p>
       {props.optInIntroHtml &&
           <div>


### PR DESCRIPTION
[4️⃣4️⃣4️⃣4️⃣ PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/state-template-spaces/explore/WY)

Changes proposed in this pull request:

- Fixes spacing issues on state page template

![The state of Wyoming chose to participate in an extended reporting process, so this page includes additional state revenue and disbursements data, as well as contextual information about state governance of natural resources with no spaces between state and revenue and state and governance](https://user-images.githubusercontent.com/32855580/63110699-e3130f00-bf40-11e9-93ad-119551e65b44.png)

