### PR TITLE
updates production text

### DIFF
--- a/src/markdown/downloads/default.md
+++ b/src/markdown/downloads/default.md
@@ -10,7 +10,7 @@ tag:
 
 # Download Data & Documentation
 
-> You can download data for production volumes, revenue, and disbursements here. All data is from the [Office of Natural Resources Revenue](https://www.onrr.gov/). 
+> You can download data for production volumes, revenue, and disbursements here. All data is from the [Office of Natural Resources Revenue](https://www.onrr.gov/).
 
 
 ## Production
@@ -24,7 +24,7 @@ tag:
   </li>
   <li class="downloads-download_links">
     <h3 id="federal-lands-and-waters">Production by year</h3>
-    <p>This dataset includes commodity volumes of natural resources extracted from federal lands and waters. Production volumes are available by state, county, and offshore area. We offer production data for calendar and fiscal years.</p>
+    <p>This dataset includes commodity volumes of natural resources extracted from federal lands and waters. Production volumes are available by state, county, and offshore area. We offer federal production data for calendar and fiscal years. We offer Native American production at the national level for fiscal year as well. </p>
     <download-data-link to="/downloads/federal-production/">Downloads and documentation</download-data-link>
   </li>
 </ul>

--- a/src/markdown/downloads/federal-production.md
+++ b/src/markdown/downloads/federal-production.md
@@ -8,6 +8,8 @@ tag:
 - Documentation
 - Federal
 - Production
+- Indian
+- Native American
 ---
 
 <custom-link to="/downloads/" className="breadcrumb link-charlie">Downloads</custom-link> /
@@ -22,7 +24,7 @@ tag:
   </ul>
 </p>
 
-<p class="downloads-download_links-intro">Download fiscal year data (2009-2018):
+<p class="downloads-download_links-intro">Download fiscal year data (2003-2018):
   <ul class="downloads-download_links list-unstyled">
     <li><excel-link to="/downloads/production/fiscal_year_production.xlsx">Fiscal year production (Excel, 409 KB)</excel-link></li>
     <li><csv-link to="/downloads/csv/production/fiscal_year_production.csv">Fiscal year production (csv, 528 KB)</csv-link></li>
@@ -31,7 +33,9 @@ tag:
 
 ## Scope
 
-This dataset includes natural resource production for U.S. federal lands and offshore areas. It does not include Native American lands, privately owned lands, or U.S. state lands. The dataset currently include data tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue (ONRR). The production data for Oil and Gas is collected on Form ONRR-4054 (Oil and Gas Operations Report). Coal and hardrock production is collected on Form ONRR-4430 (Solid Minerals Production and Royalty Report).
+<p>The calendar year dataset includes natural resource production for U.S. federal lands and offshore areas. The fiscal year dataset additionally includes Native American lands (2009-2018). Neither dataset includes privately owned lands, or U.S. state lands.<p>
+<p>Federal revenue data is available by location, but Native American data is only available at the national level to protect private and personally identifiable information.<p>
+<p>The dataset currently include data tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue (ONRR). The production data for Oil and Gas is collected on Form ONRR-4054 (Oil and Gas Operations Report). Coal and hardrock production is collected on Form ONRR-4430 (Solid Minerals Production and Royalty Report).<p>
 
 ## About the data
 


### PR DESCRIPTION
updates production text on downloads page to include native american data in the fy dataset

Fixes #4435

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/update-production-scope/)

Changes proposed in this pull request:
- updates text on main downloads page to reference native american fy data
- adds Native American and Indian tags to production by year downloads page
- edits text on production by year page to reference Native American data in fy dataset

