### PR TITLE
Removes revenue section from dives, links to other revenue rates

### DIFF
--- a/src/markdown/how-it-works/coal.md
+++ b/src/markdown/how-it-works/coal.md
@@ -72,6 +72,11 @@ permalink: /how-it-works/coal/
             <p>At the close of a coal mining operation, the lease holder must decommission the mine and restore the land. State governments, with oversight from OSMRE, regulate and oversee this process. Even before gaining a lease, the lease holder must submit a bond to OSMRE or a state regulatory agency as insurance for complying with the lease and covering the cost of <glossary-term termKey="reclamation">reclaiming</glossary-term> the land.</p>
             <p>Within coal mining, federal and local governments partner to regulate reclamation. OSMRE is responsible for establishing a nationwide program to protect society and the environment from the adverse effects of surface coal mining operations. To do so, OSMRE works with states and tribes to ensure that citizens and the environment are protected during coal mining, and that the land is restored to beneficial use when mining is finished. OSMRE and its partners are also responsible for reclaiming and restoring lands and waters degraded by mining operations before 1977.</p>
           </process-step>
+          <process-step stepName="Rates and fees">
+            <ul class="list-bullet">
+              <li><a href="/how-it-works/revenues/#coal-rates">Coal rates and fees</a></li>
+            </ul>
+          </process-step>
 		  		<process-step stepName="Learn more">
             <ul class="list-bullet">
               <li><a href="https://www.blm.gov/programs/energy-and-minerals/coal">Coal leasing</a></li>

--- a/src/markdown/how-it-works/minerals.md
+++ b/src/markdown/how-it-works/minerals.md
@@ -67,6 +67,11 @@ permalink: /how-it-works/minerals/
 		  		<process-step stepId="5" stepName="Decommission and reclaim">
             <p>In 1981, BLM issued regulations requiring miners to remove all facilities and return the land to a sound environmental state. In 2001, BLM expanded on these regulations, requiring miners to provide bonds or other financial reassurances regarding reclaiming the land before exploring or mining.</p>
           </process-step>
+          <process-step stepName="Rates and fees">
+            <ul class="list-bullet">
+              <li><a href="/how-it-works/revenues/#minerals-rates">Nonenergy minerals rates and fees</a></li>
+            </ul>
+          </process-step>
 		  		<process-step stepName="Learn more">
             <ul class="list-bullet">
               <li><a href="https://www.blm.gov/sites/blm.gov/files/documents/files/PublicRoom_Mining_Claims_Brochure-2016.pdf">Mining Claims and Sites on Federal Lands (PDF)</a></li>
@@ -78,45 +83,6 @@ permalink: /how-it-works/minerals/
 		</section>
   </div>
 </section>
-<div class="slab-beta revenues_page-forms">
-	<section class="container-outer">
-    <h1>Revenue collected by BLM and ONRR</h1>
-    <div class="revenues_page-forms_options">
-      <div>
-        <h2>Fees</h2>
-        <p class="revenues_page-forms_numbers_first">Claim-staking Fees</p>
-        <p class="revenues_page-forms_numbers"><span>$20</span>
-          <br>Processing Fee
-          <br><span>$37</span>
-          <br>Location Fee
-          <br><span>$155</span> Initial
-          <br>Maintenance Fee
-        </p>
-        <p class="revenues_page-forms_numbers">On acquired lands, one-time <span>$6,500</span> Prospecting Permit Fee</p>
-        <p class="revenues_page-forms_numbers_first">Annual Fees</p>
-        <p class="revenues_page-forms_numbers"><span>$155</span>
-        <br>Annual Maintenance Fee
-        </p>
-      </div>
-      <div>
-        <h2>Bonus</h2>
-        <p>No bonuses are paid for locatable hardrock mining</p>
-      </div>
-      <div>
-        <h2>Rent</h2>
-        <p>Miners only pay annual fees and rent on acquired lands.</p>
-        <p class="revenues_page-forms_numbers_last"><span>$0.50</span> per acre
-        <br>Prospecting Fee
-        <br><span>$1.00</span> per acre
-        <br>Rent</p>
-      </div>
-      <div>
-        <h2>Royalty</h2>
-        <p>No royalties are paid for locatable hardrock mining. Mining hardrock minerals on acquired land is exempt from minimum production and royalty requirements under <a href="http://www.gpo.gov/fdsys/pkg/CFR-2011-title43-vol2/xml/CFR-2011-title43-vol2-part3500-subpart3504.xml">Title 43 in the Code of Federal Regulations.</a></p>
-      </div>
-    </div>
-  </section>
-</div>
 <div class="slab-alpha revenues_subpage-involved">
   <section class="container-outer">
     <div class="container-left-4">

--- a/src/markdown/how-it-works/offshore-oil-gas.md
+++ b/src/markdown/how-it-works/offshore-oil-gas.md
@@ -88,6 +88,11 @@ permalink: /how-it-works/offshore-oil-gas/
             <p>BOEM requires that companies remove retired offshore drilling platforms from the marine environment within one year after the end of an operation. The lease holder is required to remove the platform from its foundation by severing all bottom-founded components at least 15 feet below the mudline and disposing of the structures in a scrap or fabrication yard. Alternatively, the platform can be used to create an artificial reef underwater.</p>
             <p>Lease holders post bonds held by the government to ensure compliance with lease terms, including decommissioning the site. If the lease holder fails to decommission the site, the government may use the bonds to cover the cost of decommissioning. If the lease holder complies, the government returns the bonds to the lease holder at the end of the operation.</p>
           </process-step>
+          <process-step stepId="6" stepName="Rates and fees">
+            <ul class="list-bullet">
+              <li><a href="/how-it-works/revenues/#oil-gas-rates">Oil and gas rates and fees</a></li>
+            </ul>
+          </process-step>
           <process-step stepName="Learn more">
             <ul class="list-bullet">
               <li><a href="http://www.boem.gov/uploadedFiles/BOEM/Oil_and_Gas_Energy_Program/Leasing/5BOEMRE_Leasing101.pdf">Oil and Gas Leasing on the Outer Continental Shelf (PDF)</a></li>
@@ -99,30 +104,6 @@ permalink: /how-it-works/offshore-oil-gas/
     </section>
   </div>
 </section>
-<div class="slab-beta revenues_page-forms">
-  <section class="container-outer">
-    <h1>Revenue collected by ONRR</h1>
-    <div class="revenues_page-forms_options">
-      <div>
-        <h2>Bonus</h2>
-        <p>The amount the highest bidder paid for a natural resource lease.</p>
-      </div>
-      <div>
-        <h2>Rent</h2>
-        <p class="revenues_page-forms_numbers_first">Starts at
-          <br><span>$7</span> or <span>$11</span> per acre, can increase to
-          <br><span>$44</span> per acre</p>
-        <p>The starting amount depends on depth, and it increases throughout the term of the lease up to <span>$44.00</span> per acre in some cases.</p>
-      </div>
-      <div>
-        <h2>Royalty</h2>
-        <p class="revenues_page-forms_numbers"><span>12.5%, 16.67%,</span> or <span>18.75%</span></p>
-      </div>
-      <div>
-      </div>
-    </div>
-  </section>
-</div>
 <div class="slab-alpha revenues_subpage-involved">
   <section class="container-outer">
     <div class="container-left-4">

--- a/src/markdown/how-it-works/offshore-renewables.md
+++ b/src/markdown/how-it-works/offshore-renewables.md
@@ -76,6 +76,11 @@ permalink: /how-it-works/offshore-renewables/
             <p>During this period, ONRR collects annual rent from the lease holder. Once the wind facility produces energy, ONRR also collects an <glossary-term termKey="operating fee">Operating Fee</glossary-term>.</p>
             <p>Prior to the end of the lease term, the developer must submit a plan to decommission the facilities.</p>
           </process-step>
+          <process-step stepName="Rates and fees">
+            <ul class="list-bullet">
+              <li><a href="/how-it-works/revenues/#solar-wind-rates">Oil and gas rates and fees</a></li>
+            </ul>
+          </process-step>
           <process-step stepName="Learn more">
             <ul class="list-bullet">
               <li><a href="http://www.boem.gov/Renewable-Energy/">Renewable Energy</a></li>

--- a/src/markdown/how-it-works/onshore-oil-gas.md
+++ b/src/markdown/how-it-works/onshore-oil-gas.md
@@ -82,6 +82,11 @@ permalink: /how-it-works/onshore-oil-gas/
             <p>The lease holder also posts a bond of at least $10,000 that BLM holds during the operation to enforce lease terms and reclamation. The operator must conduct interim reclamation throughout the life of the operation, concluding with appropriately plugging wells and restoring the ecosystem.</p>
             <p>The BLM field office performs inspections throughout the operation to ensure that interim reclamation takes place, wells are appropriately plugged, and the ecosystem returns.</p>
           </process-step>
+          <process-step stepName="Rates and fees">
+            <ul class="list-bullet">
+              <li><a href="/how-it-works/revenues/#oil-gas-rates">Oil and gas rates and fees</a></li>
+            </ul>
+          </process-step>
           <process-step stepName="Learn more">
             <ul class="list-bullet">
             <li><a href="https://www.blm.gov/programs/energy-and-minerals/oil-and-gas/leasing">Leasing of Onshore Oil and Gas Resources</a></li>

--- a/src/markdown/how-it-works/onshore-renewables.md
+++ b/src/markdown/how-it-works/onshore-renewables.md
@@ -73,6 +73,11 @@ permalink: /how-it-works/onshore-renewables/
             <p>Bonding requirements differ based on whether the project is in a designed leasing area or not. Inside designated leasing areas, the standard bond amounts would be $10,000 per acre for solar energy projects and $20,000 per turbine for wind energy projects. These same amounts would be the minimum requirements for bonds outside designated leasing areas, subject to adjustment by BLM.</p>
             <p>If the developer appropriately decommissions solar and wind projects and meets terms and conditions, BLM returns the bond at the close of the project.</p>
           </process-step>
+          <process-step stepName="Rates and fees">
+            <ul class="list-bullet">
+              <li><a href="/how-it-works/revenues/#oil-gas-rates">Oil and gas rates and fees</a></li>
+            </ul>
+          </process-step>
           <process-step stepName="Learn more">
             <ul class="list-bullet">
               <li><a href="https://www.blm.gov/programs/energy-and-minerals/renewable-energy/solar-energy">Solar Energy</a></li>
@@ -84,34 +89,6 @@ permalink: /how-it-works/onshore-renewables/
     </section>
   </div>
 </section>
-<div class="slab-beta revenues_page-forms">
-  <section class="container-outer">
-    <h1>Revenue collected by BLM</h1>
-    <div class="revenues_page-forms_options">
-      <div>
-        <h2>Bonus</h2>
-        <p>The amount the highest bidder will pay for a natural resource lease.</p>
-      </div>
-      <div>
-        <h2>Rent</h2>
-        <p>Rent is determined by the acre and based on land values.</p>
-      </div>
-      <div>
-        <h2>Fees</h2>
-        <p class="revenues_page-forms_numbers_first">
-          <span>$5,010</span> per MW
-          <br>annual wind fee
-          <br><br><span>$2,863–$4,294</span> per MW
-          <br>annual solar fee
-        </p>
-        <p>Solar fees are based on solar type and storage capacity.</p>
-      </div>
-      <div>
-        <em>Note: wind and solar fees are expressed as <glossary-term termKey="Megawatt Capacity (MC) fee">Megawatt Capacity fees</glossary-term>.</em>
-      </div>
-    </div>
-  </section>
-</div>
 <div class="slab-alpha revenues_subpage-involved">
   <section class="container-outer">
     <div class="container-left-4">

--- a/src/markdown/how-it-works/revenues.md
+++ b/src/markdown/how-it-works/revenues.md
@@ -29,7 +29,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 <h3 data-toc-exclude="true">Revenue streams and rates</h3>
 
 <!--Oil and gas-->
-<p style="margin: 2em 0 0 0;"><oil-gas-icon></oil-gas-icon> <strong>Oil and gas</strong></p>
+<h4 id="oil-gas-rates" style="margin: 2em 0 0 0;"><oil-gas-icon></oil-gas-icon> Oil and gas</h4>
 
 <table class="article_table">
   <thead>
@@ -66,7 +66,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 </table>
 
 <!--Coal-->
-<p style="margin: 2em 0 0 0;"><coal-icon></coal-icon> <strong>Coal</strong></p>
+<h4 id="coal-rates" style="margin: 2em 0 0 0;"><coal-icon></coal-icon> Coal</h4>
 
 <table class="article_table">
   <thead>
@@ -102,7 +102,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 </table>
 
 <!--Hardrock minerals-->
-<p style="margin: 2em 0 0 0;"><hardrock-icon></hardrock-icon> <strong>Hardrock minerals</strong></p>
+<h4 id="minerals-rates" style="margin: 2em 0 0 0;"><hardrock-icon></hardrock-icon> <strong>Hardrock minerals</strong></h4>
 
 <table class="article_table">
   <thead>
@@ -142,7 +142,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 </table>
 
 <!--Solar and wind energy-->
-<p style="margin: 2em 0 0 0;"><renewables-icon></renewables-icon> <strong>Solar and wind energy</strong></p>
+<h4 id="solar-wind-rates" style="margin: 2em 0 0 0;"><renewables-icon></renewables-icon> <strong>Solar and wind energy</strong></h4>
 
 <table class="article_table">
   <thead>
@@ -186,7 +186,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 <p class="para-sm">* Unless waived or otherwise specified</p>
 
 <!--Geothermal-->
-<p style="margin: 2em 0 0 0;"><geothermal-icon></geothermal-icon> <strong>Geothermal</strong></p>
+<h4 id="geothermal-rates" style="margin: 2em 0 0 0;"><geothermal-icon></geothermal-icon> <strong>Geothermal</strong></h4>
 
 <table class="article_table">
   <thead>


### PR DESCRIPTION


[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/removes-fees-section/how-it-works/minerals/)

Changes proposed in this pull request:

- Removes rates, revenues section from all dive-in pages.
- Rationale: We maintain rates and fees content in three separate places, and the rates change with some frequency. This approach removes one instance on an otherwise static, contextual page, and links to another place in `how-it-works` where we recently updated the content.
