### PR TITLE
Adds 'skip to main content' for accessibility

### DIFF
--- a/src/components/layouts/DefaultLayout/DefaultLayout.js
+++ b/src/components/layouts/DefaultLayout/DefaultLayout.js
@@ -10,6 +10,7 @@ import { Footer } from '../Footer'
 import Glossary from '../../utils/Glossary'
 import utils from '../../../js/utils'
 
+import styles from '../../../css-global/base-theme.module.scss'
 import '../../../styles/_main.scss'
 // import "../../../styles/print.scss";
 
@@ -80,6 +81,8 @@ const DefaultLayout = ({ children }) => {
           {'<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NCRF98R" height="0" width="0" style="display:none;visibility:hidden"></iframe>'}
         </noscript>
       </Helmet>
+
+      <a href="#main-content" className={styles.skipNav}>Skip to main content</a>  
 
       <Banner />
 

--- a/src/components/layouts/Header/Header.js
+++ b/src/components/layouts/Header/Header.js
@@ -52,6 +52,7 @@ const Header = props => {
   }
   return (
     <header className={styles.root + ' container-page-wrapper'}>
+      <a class="skipnav" href="#main-content">Skip to main content</a>
       { isIE && <BrowserBanner /> }
       <div className="header-left">
         <Link className="header-image_link" to="/">

--- a/src/components/layouts/Header/Header.js
+++ b/src/components/layouts/Header/Header.js
@@ -52,7 +52,6 @@ const Header = props => {
   }
   return (
     <header className={styles.root + ' container-page-wrapper'}>
-      <a class="skipnav" href="#main-content">Skip to main content</a>
       { isIE && <BrowserBanner /> }
       <div className="header-left">
         <Link className="header-image_link" to="/">

--- a/src/components/layouts/Header/Header.module.scss
+++ b/src/components/layouts/Header/Header.module.scss
@@ -1,5 +1,5 @@
 @value colors: "../../../css-global/colors.scss";
-@value blue as --blue, white as --white from colors;
+@value blue as --blue, white as --white, grayDarkest as _grayDarkest from colors;
 
 @value variables: '../../../css-global/variables.scss';
 @value baseFontFamily as --baseFontFamily from variables;
@@ -69,4 +69,15 @@
   line-height: 1.375rem;
   margin-bottom: 0.625rem;
   padding-bottom: 1.6em;
+}
+
+.skipnav {
+  background: transparent;
+  color: _grayDarkest;
+  left: 0;
+  padding: 1rem 1.5rem;
+  position: absolute;
+  top: -4.2rem;
+  transition: all 0.2s ease-in-out;
+  z-index: 100;
 }

--- a/src/components/layouts/Header/Header.module.scss
+++ b/src/components/layouts/Header/Header.module.scss
@@ -70,14 +70,3 @@
   margin-bottom: 0.625rem;
   padding-bottom: 1.6em;
 }
-
-.skipnav {
-  background: transparent;
-  color: _grayDarkest;
-  left: 0;
-  padding: 1rem 1.5rem;
-  position: absolute;
-  top: -4.2rem;
-  transition: all 0.2s ease-in-out;
-  z-index: 100;
-}

--- a/src/css-global/base-theme.module.scss
+++ b/src/css-global/base-theme.module.scss
@@ -37,3 +37,24 @@
   border-bottom: 10px solid _greenLight;
   padding-bottom: .7rem;
 }
+
+.skipNav {
+	position: absolute;
+	top: -1000px;
+	left: -1000px;
+	height: 1px;
+	width: 1px;
+	text-align: left;
+	overflow: hidden;
+
+	&:active, 
+	&:focus, 
+	&:hover {
+		left: 0; 
+		top: 0;
+		padding: 5px;
+		width: auto; 
+		height: auto; 
+		overflow: visible;
+	}
+}

--- a/src/markdown/archive/default.md
+++ b/src/markdown/archive/default.md
@@ -35,7 +35,7 @@ tag:
 </section>
 
 <div class="container-page-wrapper">
-  <main class="container-page-wrapper">
+  <main class="container-page-wrapper" id="main-content">
    <div class="container-left-8 container-shift-reverse-1"> 
     <section class="container-padded-top">
       <h2 id="history">History</h2>

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -4,8 +4,8 @@ layout: howitworks-default
 permalink: /how-it-works/
 redirect_from: /how-it-works/production/
 ---
-<main class="container-page-wrapper landing-wrapper" id="main-content">
-<section class="slab-delta">
+
+<section class="slab-delta" id="main-content">
   <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
     <div class="container-left-8 ribbon-hero ribbon-hero-column">
       <h1 id="introduction">How It Works</h1>
@@ -24,6 +24,7 @@ redirect_from: /how-it-works/production/
   </div>
 </section>
 <div class="container-page-wrapper landing-wrapper">
+  <main class="container-page-wrapper landing-wrapper">
     <article class="container-left-8 container-shift-reverse-1">
       <section class="container">
         <h2 id="ownership" alt="Land ownership" class="h2-bar">Who owns natural resources in the U.S.?</h2>
@@ -176,7 +177,7 @@ redirect_from: /how-it-works/production/
         </div>
       </section>
     </article>
-   </main> 
     <div class="container-right-3 how-it-works-page-toc">     
       <page-toc scroll.offset='-50' exclude.class.names='h3'></page-toc>
     </div>
+  </main>

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -4,8 +4,8 @@ layout: howitworks-default
 permalink: /how-it-works/
 redirect_from: /how-it-works/production/
 ---
-
-<section class="slab-delta" id="main-content">
+<main class="container-page-wrapper landing-wrapper" id="main-content">
+<section class="slab-delta">
   <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
     <div class="container-left-8 ribbon-hero ribbon-hero-column">
       <h1 id="introduction">How It Works</h1>

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -176,7 +176,7 @@ redirect_from: /how-it-works/production/
         </div>
       </section>
     </article>
+   </main> 
     <div class="container-right-3 how-it-works-page-toc">     
       <page-toc scroll.offset='-50' exclude.class.names='h3'></page-toc>
     </div>
-</main>

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -4,7 +4,7 @@ layout: howitworks-default
 permalink: /how-it-works/
 redirect_from: /how-it-works/production/
 ---
-
+<main class="container-page-wrapper landing-wrapper" id="main-content">
 <section class="slab-delta">
   <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
     <div class="container-left-8 ribbon-hero ribbon-hero-column">
@@ -24,7 +24,6 @@ redirect_from: /how-it-works/production/
   </div>
 </section>
 <div class="container-page-wrapper landing-wrapper">
-  <main class="container-page-wrapper landing-wrapper">
     <article class="container-left-8 container-shift-reverse-1">
       <section class="container">
         <h2 id="ownership" alt="Land ownership" class="h2-bar">Who owns natural resources in the U.S.?</h2>
@@ -180,4 +179,4 @@ redirect_from: /how-it-works/production/
     <div class="container-right-3 how-it-works-page-toc">     
       <page-toc scroll.offset='-50' exclude.class.names='h3'></page-toc>
     </div>
-  </main>
+</main>

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -4,8 +4,8 @@ layout: howitworks-default
 permalink: /how-it-works/
 redirect_from: /how-it-works/production/
 ---
-<main class="container-page-wrapper landing-wrapper" id="main-content">
-<section class="slab-delta">
+
+<section class="slab-delta" id="main-content">
   <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
     <div class="container-left-8 ribbon-hero ribbon-hero-column">
       <h1 id="introduction">How It Works</h1>

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -26,7 +26,7 @@ const AboutPage = () => {
             { name: 'og:title', content: 'About | Natural Resources Revenue Data' },
             { name: 'twitter:title', content: 'About | Natural Resources Revenue Data' },
           ]} />
-
+        <main id="main-content">
         <section className="slab-delta">
           <div className="container-page-wrapper ribbon ribbon-column landing-section_top">
             <div className="container-left-8 ribbon-hero ribbon-hero-column">
@@ -170,7 +170,7 @@ const AboutPage = () => {
           </section>
 
         </div>
-
+        </main>  
       </div>
     </DefaultLayout>
   )

--- a/src/pages/explore/index.js
+++ b/src/pages/explore/index.js
@@ -90,7 +90,7 @@ class ExplorePage extends React.Component {
   render () {
     return (
       <DefaultLayout>
-        <main id="national" className="layout-state-pages national-page">
+        <main id="main-content" className="layout-state-pages national-page">
           <Helmet
             title="Explore data | Natural Resources Revenue Data"
             meta={[

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -97,7 +97,7 @@ class HomePage extends React.Component {
   render () {
     return (
       <DefaultLayout>
-        <main>
+        <main id="main-content">
           <Helmet
             title="Home | Natural Resources Revenue Data"
             meta={[

--- a/src/templates/case-studies-template.js
+++ b/src/templates/case-studies-template.js
@@ -33,7 +33,7 @@ class CaseStudiesTemplate extends React.Component {
 
     return (
       <DefaultLayout>
-        <main>
+        <main id="main-content">
           <Helmet
             title={title}
             meta={[

--- a/src/templates/content-default.js
+++ b/src/templates/content-default.js
@@ -39,7 +39,7 @@ class DefaultTemplate extends React.Component {
 
     return (
       <DefaultLayout>
-        <main>
+        <main id="main-content">
           <Helmet
             title={title}
             meta={[

--- a/src/templates/downloads-default.js
+++ b/src/templates/downloads-default.js
@@ -20,7 +20,7 @@ class DownloadsTemplate extends React.Component {
 
     return (
       <DefaultLayout>
-        <main>
+        <main id="main-content">
           <Helmet
             title={title}
             meta={[


### PR DESCRIPTION
[🔶 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/skip-to-main/)

Changes proposed in this pull request:

- Adds 'hidden' skip to main link
- To preview, navigate to a page and hit `Tab`
- This pattern allows keyboard users to bypass the navigation on pages in which they wish to jump to the main content, without having to tab through the navigation items on every page. It is especially useful for screen-reader users, for whom repeating navigation on every page can be a significant barrier.

![Layout of natural resources revenue data homepage with top left navigation of skip to main content](https://user-images.githubusercontent.com/32855580/63629060-c3c15500-c5c4-11e9-8eab-0e296c4481a2.png)
