### PR TITLE
Adds skip to main anchor id back to homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -121,7 +121,7 @@ class Beta extends React.Component {
 		      { name: 'twitter:title', content: 'Home | Natural Resources Revenue Data' },
 		  ]} >
 		</Helmet>
-	        <section className="container-page-wrapper" >
+	        <section id="main-content" className="container-page-wrapper" >
 		<h3 className="h3-bar"></h3>
 		<p> When companies extract energy and mineral resources on property leased from the federal government and Native Americans, they pay <GlossaryTerm termKey="Bonus">bonuses</GlossaryTerm>, <GlossaryTerm>rent</GlossaryTerm>, and <GlossaryTerm termKey="Royalty">royalties</GlossaryTerm>. The Office of Natural Resources Revenue (ONRR) collects and <GlossaryTerm termKey="disbursement">disburses</GlossaryTerm> revenue from federal lands and waters to different agencies, funds, and local governments for public use. All revenue collected from extraction on Native American lands is disbursed to Native American tribes, nations, or individuals.</p>
 		</section>


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/main-content/)

Changes proposed in this pull request:

In a previous pull request, I added a "Skip to main content" link for accessibility. The anchor `id` it linked to was omitted in our homepage update. This branch adds it back.

When the preview loads, hit `Tab` and `Enter`. It should link down the page to the main content area.
