### PR TITLE
updates disbursement download page

### DIFF
--- a/src/markdown/downloads/disbursements-by-month.md
+++ b/src/markdown/downloads/disbursements-by-month.md
@@ -112,4 +112,3 @@ _Category (dollar)_ Includes, but not limited to, phases of lease payments, such
 _Disbursement (dollar)_ The amount disbursed.
 
 ## Contact us
-Do you have questions about the data or need data that isn't here? Contact our data specialists at onrrdatarequests@onrr.gov.

--- a/src/markdown/downloads/disbursements-by-month.md
+++ b/src/markdown/downloads/disbursements-by-month.md
@@ -41,8 +41,8 @@ _Calendar Year_ The period between January 1 and December 31 for a given year.
 
 _Fund Type_ The type of recipient receiving the disbursement
 
-* _BLM-Nat Petrol Reserve-2_  Funds from oil and gas leases directed to the National Petroleum Reserve in Alaska.
-* _Bureau of Land Management_  Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
+* _BLM-Nat Petrol Reserve-2_ Funds from oil and gas leases directed to the National Petroleum Reserve in Alaska.
+* _Bureau of Land Management_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
 * _Bureau of Ocean Energy Management_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
 * _Bureau of Safety & Environmental Enforcement_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
 * _Fish & Wildlife_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
@@ -52,8 +52,8 @@ _Fund Type_ The type of recipient receiving the disbursement
 * _Native American Tribes & Allottees_ ONRR disburses 100% of revenue collected from resource extraction on Native American lands back to Native American  tribes, nations, and individual Indian landowners.
 * _Reclamation Fund_ Established by Congress in 1902, funds the development of irrigation projects on arid and semiarid lands of the 17 western states.
 * _State Fund_ disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.
-* _U.S Treasury Fund_ disbursed to the Treasury go to the General Fund, which is the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the U.S. military, national parks, and schools.
-* _U.S. TreasuryAI Funds_ disbursed to Native American deposit accounts within the U.S. Treasury Deposit accounts are funds that are collected by the U.S. Treasury but do not belong to the federal government.
+* _U.S Treasury_ Funds disbursed to the Treasury go to the General Fund, which is the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the U.S. military, national parks, and schools.
+* _U.S. TreasuryAI_ Funds disbursed to Native American deposit accounts within the U.S. Treasury Deposit accounts are funds that are collected by the U.S. Treasury but do not belong to the federal government.
 
 _Land Category_ Whether the origin of the revenue being disbursed is offshore or onshore
 
@@ -81,7 +81,7 @@ _Commodity_ The commodity that generated the revenue. For oil and gas, the commo
 
 * _Hardrock_
 
-* _Lead/Zinc_ 
+* _Lead/Zinc_
 
 * _Limestone_
 

--- a/src/markdown/downloads/disbursements-by-month.md
+++ b/src/markdown/downloads/disbursements-by-month.md
@@ -65,32 +65,49 @@ _County_ The county, parish, or borough that received the disbursement in accord
 
 _Commodity_ The commodity that generated the revenue. For oil and gas, the commodity listed depends on the phase of production. Since it's unknown whether a lease will produce oil, gas, or both, the two commodities are combined in the bonus and rent phases and listed as "Oil & Gas."
 
-*_Clay_
-*_Coal_
-*_Copper_
-*_Gas_
-*_Geothermal_
-*_Gilsonite
-*_Gold_
-*_Hardrock_
-*_Lead/Zinc_
-*_Limestone_
-*_Oil_
-*_Oil & Gas_
-*_Oil Shale_
-*_Phosphate_
-*_Potassium_
-*_Quartz_
-*_Sodium_
-*_Wind_
+* _Clay_ 
 
-_Categpry (dollar)_ Includes, but not limited to, phases of lease payments, such as bonuses, rents, and royalties.
+* _Coal_
 
-*_Bonuses_ The amount paid by the highest bidder for a natural resource lease.
-*_Rents_ The annual payment for leasing lands or waters before production starts.
-*_Royalties_ Payments for extracted natural resources, determined by a percentage of the resources’ production value.
-*_Other Distributions_ Revenues from fees and civil penalties.
-*_Sequestration_ represents [statutory spending limits](https://www.cbo.gov/topics/budget/sequestration) which are withheld from certain government programs. Some program funds are returned in following fiscal year.
+* _Copper_
+
+* _Gas_
+
+* _Geothermal_
+
+* _Gilsonite_
+
+* _Gold_
+
+* _Hardrock_
+
+* _Lead/Zinc_ 
+
+* _Limestone_
+
+* _Oil_
+
+* _Oil & Gas_
+
+* _Oil Shale_
+
+* _Phosphate_
+
+* _Potassium_
+
+* _Quartz_
+
+* _Sodium_
+
+* _Wind_
+
+_Category (dollar)_ Includes, but not limited to, phases of lease payments, such as bonuses, rents, and royalties.
+
+* _Bonuses_ The amount paid by the highest bidder for a natural resource lease.
+* _Rents_ The annual payment for leasing lands or waters before production starts.
+* _Royalties_ Payments for extracted natural resources, determined by a percentage of the resources’ production value.
+* _Other Distributions_ Revenues from fees and civil penalties.
+* _Sequestration_ represents [statutory spending limits](https://www.cbo.gov/topics/budget/sequestration) which are withheld from certain government programs. Some program funds are returned in following fiscal year.
 
 _Disbursement (dollar)_ The amount disbursed.
 

--- a/src/markdown/downloads/disbursements-by-month.md
+++ b/src/markdown/downloads/disbursements-by-month.md
@@ -13,9 +13,9 @@ tag:
 <custom-link to="/downloads/" className="breadcrumb link-charlie">Downloads</custom-link> /
 # Disbursements by month
 
-> The amount of money earned from extraction of natural resources on federal lands that is disbursed to various legislated funds. We have disbursements data by month from October 2018 through the most recent month.
+> Revenue collected from extraction of natural resources on federal and Native American lands is distributed to various legislated funds, local governments, and federal agencies. This process is called disbursement. We have disbursements data by month from October 2018 through the most recent month .
 
-Download fiscal year data:
+Download disbursement by month data:
 
 <ul class="downloads-download_links list-unstyled">
   <li><excel-link to="/downloads/disbursements/monthly_disbursements.xlsx">Disbursements by month (Excel, 196 KB)</excel-link></li>
@@ -24,7 +24,7 @@ Download fiscal year data:
 
 ## Scope
 
-This dataset includes natural resource disbursements for U.S. federal lands, federal offshore areas, and Indian lands. It does not include privately owned lands or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. Disbursements of revenue from extractive activities on U.S. federal lands occur monthly. The data contains disbursement payments by month to state and local governments, designated funds, and the U.S. Treasury from October 2018 through the most recently available month.
+This dataset includes natural resource disbursements for U.S. federal lands, federal offshore areas, and Native American lands. It does not include privately owned lands or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. Disbursements of revenue from extractive activities on U.S. federal lands occur bi-weekly. The data contains disbursement payments by month to state and local governments, designated funds, and the U.S. Treasury from October 2018 through the most recently available month.
 
 ## Data publication
 
@@ -32,13 +32,28 @@ We publish the monthly file when we receive the data for the most recently avail
 
 ## Data dictionary
 
-Laws treat revenues from offshore natural resources and onshore natural resources differently. There are set percentages and amounts from each that go certain funds or local governments.
+### Fields and definitions
+Laws treat revenues from offshore natural resources and onshore natural resources differently. There are set percentages and amounts from each that go to specific funds, local governments, or government agencies. All revenue collected from Native American lands is disbursed back to Native American tribes, nations, or individuals.
 
 _Month_ The month the disbursement occurred
 
-_Year_ The year the disbursement occurred
+_Calendar Year_ The period between January 1 and December 31 for a given year.
 
 _Fund Type_ The type of recipient receiving the disbursement
+
+* _BLM-Nat Petrol Reserve-2_  Funds from oil and gas leases directed to the National Petroleum Reserve in Alaska.
+* _Bureau of Land Management_  Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
+* _Bureau of Ocean Energy Management_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
+* _Bureau of Safety & Environmental Enforcement_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
+* _Fish & Wildlife_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
+* _Forest Service_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
+* _Land & Water Conservation Fund_ This fund provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states. The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies that 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million a year in funding. This portion of LWCF funds is not subject to the congressional appropriation process, but are otherwise treated similarly to regular LWCF funds.
+* _Lease Process Improvement (BLM)_ Permit Processing Fund, Bureau of Land Management (BLM), was established by the Department of the Interior as authorized by 119 Stats. 725, 671, and 695, for the deposit of mineral lease rentals. The Department of the Interior is authorized to use funds for the coordination and processing of oil and gas use authorizations on Federal land onshore, under the jurisdiction of the Pilot Project offices.
+* _Native American Tribes & Allottees_ ONRR disburses 100% of revenue collected from resource extraction on Native American lands back to Native American  tribes, nations, and individual Indian landowners.
+* _Reclamation Fund_ Established by Congress in 1902, funds the development of irrigation projects on arid and semiarid lands of the 17 western states.
+* _State Fund_ disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.
+* _U.S Treasury Fund_ disbursed to the Treasury go to the General Fund, which is the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the U.S. military, national parks, and schools.
+* _U.S. TreasuryAI Funds_ disbursed to Native American deposit accounts within the U.S. Treasury Deposit accounts are funds that are collected by the U.S. Treasury but do not belong to the federal government.
 
 _Land Category_ Whether the origin of the revenue being disbursed is offshore or onshore
 
@@ -46,12 +61,38 @@ _Disbursement Type_ Disbursement types are guided by revenue-sharing legislation
 
 _State_ The state that received the disbursement in accordance with revenue-sharing legislation
 
-_County_ The county that received the disbursement in accordance with revenue-sharing legislation
+_County_ The county, parish, or borough that received the disbursement in accordance with revenue-sharing legislation
 
 _Commodity_ The commodity that generated the revenue. For oil and gas, the commodity listed depends on the phase of production. Since it's unknown whether a lease will produce oil, gas, or both, the two commodities are combined in the bonus and rent phases and listed as "Oil & Gas."
 
-_Category_ Includes phases of lease payments, such as bonuses, rents, and royalties. The column also includes "Other Distributions," which include revenues derived from fees and civil penalties. Finally, the column includes "Sequestration," which represents [statutory spending limits](https://www.cbo.gov/topics/budget/sequestration) which are withheld from certain government programs. Some program funds are returned in following fiscal year.
+*_Clay_
+*_Coal_
+*_Copper_
+*_Gas_
+*_Geothermal_
+*_Gilsonite
+*_Gold_
+*_Hardrock_
+*_Lead/Zinc_
+*_Limestone_
+*_Oil_
+*_Oil & Gas_
+*_Oil Shale_
+*_Phosphate_
+*_Potassium_
+*_Quartz_
+*_Sodium_
+*_Wind_
 
-_Disbursement_ The amount disbursed
+_Categpry (dollar)_ Includes, but not limited to, phases of lease payments, such as bonuses, rents, and royalties.
+
+*_Bonuses_ The amount paid by the highest bidder for a natural resource lease.
+*_Rents_ The annual payment for leasing lands or waters before production starts.
+*_Royalties_ Payments for extracted natural resources, determined by a percentage of the resources’ production value.
+*_Other Distributions_ Revenues from fees and civil penalties.
+*_Sequestration_ represents [statutory spending limits](https://www.cbo.gov/topics/budget/sequestration) which are withheld from certain government programs. Some program funds are returned in following fiscal year.
+
+_Disbursement (dollar)_ The amount disbursed.
 
 ## Contact us
+Do you have questions about the data or need data that isn't here? Contact our data specialists at onrrdatarequests@onrr.gov.

--- a/src/markdown/downloads/disbursements-by-month.md
+++ b/src/markdown/downloads/disbursements-by-month.md
@@ -48,10 +48,10 @@ _Fund Type_ The type of recipient receiving the disbursement
 * _Fish & Wildlife_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
 * _Forest Service_ Certain funds are directed back to the federal agencies that administer these lands and waters to help cover the agencies’ operational costs.
 * _Land & Water Conservation Fund_ This fund provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states. The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies that 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million a year in funding. This portion of LWCF funds is not subject to the congressional appropriation process, but are otherwise treated similarly to regular LWCF funds.
-* _Lease Process Improvement (BLM)_ Permit Processing Fund, Bureau of Land Management (BLM), was established by the Department of the Interior as authorized by 119 Stats. 725, 671, and 695, for the deposit of mineral lease rentals. The Department of the Interior is authorized to use funds for the coordination and processing of oil and gas use authorizations on Federal land onshore, under the jurisdiction of the Pilot Project offices.
+* _Lease Process Improvement (BLM)_ This fund was established to support the coordination and processing of oil and gas leases on federal onshore land.
 * _Native American Tribes & Allottees_ ONRR disburses 100% of revenue collected from resource extraction on Native American lands back to Native American  tribes, nations, and individual Indian landowners.
 * _Reclamation Fund_ Established by Congress in 1902, funds the development of irrigation projects on arid and semiarid lands of the 17 western states.
-* _State Fund_ disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.
+* _State Fund_ Funds disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.
 * _U.S Treasury_ Funds disbursed to the Treasury go to the General Fund, which is the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the U.S. military, national parks, and schools.
 * _U.S. TreasuryAI_ Funds disbursed to Native American deposit accounts within the U.S. Treasury Deposit accounts are funds that are collected by the U.S. Treasury but do not belong to the federal government.
 
@@ -101,7 +101,7 @@ _Commodity_ The commodity that generated the revenue. For oil and gas, the commo
 
 * _Wind_
 
-_Category (dollar)_ Includes, but not limited to, phases of lease payments, such as bonuses, rents, and royalties.
+_Category (dollar)_ Includes the phases of lease payments.
 
 * _Bonuses_ The amount paid by the highest bidder for a natural resource lease.
 * _Rents_ The annual payment for leasing lands or waters before production starts.

--- a/src/markdown/downloads/disbursements.md
+++ b/src/markdown/downloads/disbursements.md
@@ -13,7 +13,7 @@ tag:
 <custom-link to="/downloads/" className="breadcrumb link-charlie">Downloads</custom-link> /
 # Disbursements by Year
 
-> The amount of money earned from extraction of natural resources on federal lands that is disbursed to various legislated funds. Our fund overview dataset is from the Office of Natural Resources Revenue, which is part of the Department of the Interior.
+> Revenue collected from extraction of natural resources on federal and Native American lands that is distributed to various legislated funds, local governments, and federal agencies. This process is called disbursement. We have disbursements data by fiscal year from 2003 to present.
 
 Download fiscal year data:
 
@@ -24,7 +24,7 @@ Download fiscal year data:
 
 ## Scope
 
-This dataset includes natural resource disbursements for U.S. federal lands, federal offshore areas, and Indian lands. It does not include privately owned lands or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. It contains disbursement information to funds for fiscal years 2003-2018. Disbursements of revenue from extractive activities on U.S. federal lands occur monthly; this dataset is a sum of those disbursements by fiscal year.
+This dataset includes natural resource disbursements for U.S. federal lands, federal offshore areas, and Native American lands. It does not include privately owned lands or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. It contains disbursement information to funds for fiscal years 2003-2018. Disbursements of revenue from extractive activities on U.S. federal lands occur monthly; this dataset is a sum of those disbursements by fiscal year.
 
 ## Data publication
 
@@ -32,57 +32,32 @@ The disbursement dataset is updated in November after the end of the federal gov
 
 ## Data dictionary
 
-Laws treat revenues from offshore natural resources and onshore natural resources differently. There are set percentages and amounts from each that go certain places every year.
+### Fields and Definitions
+Laws treat revenues from offshore natural resources and onshore natural resources differently. There are set percentages and amounts from each that go to specific funds, local governments, or government agencies. All revenue collected from Native American lands is disbursed back to Native American tribes, nations, or individuals.
 
-### Onshore
+_Fiscal Year_ The year the disbursement occurred. The federal fiscal year runs from October 1 of the prior year through September 30 of the year being described. For example, Fiscal Year 2018 is between October 1, 2017,  and September 30, 2018.
 
-_U.S. Treasury_ Funds disbursed to the Treasury go to the General Fund, which is the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the U.S. military, national parks, and schools.
+_Fund Type_ The type of recipient receiving the disbursement.
 
-_States_ Funds disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.
+* _U.S. Treasury_ Funds disbursed to the Treasury go to the General Fund, which is the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the U.S. military, national parks, and schools.
+* _U.S. Treasury GoMESA_ The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies that 50% of revenues from certain gulf leases be directed to the U.S. Treasury.
+* _American Indian Tribes_ ONRR disburses 100% of revenue collected from resource extraction on Native American lands back to Native American tribes, nations, and individuals.
+* _Land and Water Conservation_ Fund This fund provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states.
+* _Land and Water Conservation Fund GoMESA_ The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies that 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million a year in funding. This portion of LWCF funds is not subject to the congressional appropriation process, but are otherwise treated similarly to regular LWCF funds.
+* _Historic Preservation Fund_ This fund helps preserve U.S. historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices.
+* _Reclamation_ Established by Congress in 1902 to pay for Bureau of Reclamation projects, this fund supports the establishment of critical infrastructure projects like dams and power plants.
+* _State_ Funds disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.
+* _State 8(g)_ 27% of revenue from leases in the 8(g) Zone (the first three nautical miles of the Outer Continental Shelf) are shared with states.
+* _State GoMESA_ 37.5% of revenue from certain leases in the Gulf of Mexico are shared with Alabama, Louisiana, Mississippi, and Texas.
+* _Other_ Certain funds are directed back to the federal agencies that administer these lands (e.g., BLM, U.S. Fish and Wildlife Service, and U.S. Forest Service) to help cover the agencies’ operational costs. The Ultra-Deepwater Research Program and the Mescal Settlement Agreement also receive $50 million each.
 
-_Reclamation_ Established by Congress in 1902 to pay for Bureau of Reclamation projects, this fund supports the establishment of critical infrastructure projects like dams and power plants.
+_Onshore/Offshore_ Whether the origin of the revenue being disbursed is offshore or onshore.
 
-_American Indian Tribes_ ONRR disburses 100% of revenue collected from resource extraction on American Indian lands back to the Indian tribes and individual Indian landowners.
+_State_ The state that received the disbursement in accordance with revenue-sharing legislation.
 
-_Other_ Certain onshore funds are directed back to the federal agencies that administer these lands (e.g., BLM, U.S. Fish and Wildlife Service, and U.S. Forest Service) to help cover the agencies’ operational costs. The Ultra-Deepwater Research Program and the Mescal Settlement Agreement also receive $50 million each.
+_County_ The county that received the disbursement in accordance with revenue-sharing legislation.
 
-### Offshore
-
-_U.S. Treasury_ The majority of offshore revenue is disbursed to the Treasury, which enters it into the General Fund, the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the U.S. military, national parks, and schools.
-
-_Land and Water Conservation Fund_ This fund provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states.
-
-_Historic Preservation Fund_ This fund helps preserve U.S. historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices.
-
-_States_ States receive federal Outer Continental Shelf revenue in two ways:
-
-- 27% of revenue from leases in the 8(g) Zone (the first three nautical miles of the Outer Continental Shelf) are shared with states.
-- 37.5% of revenue from certain leases in the Gulf of Mexico are shared with Alabama, Louisiana, Mississippi, and Texas.
-
-_Other_ Certain offshore funds are directed back to the federal agencies that administer these lands (e.g., BOEM and BSEE) to help cover the agencies’ operational costs.
-
-## Archive
-
-In the past, this site has offered detailed data for disbursements distributed from other funds. For example, the data below details disbursements to sub-funds of the Land and Water Conservation Fund and the Historic Preservation Fund.
-
-### Land and Water Conservation Fund
-
-<glossary-term>ONRR</glossary-term> disburses revenue to the [Land and Water Conservation Fund (LWCF)](https://www.nps.gov/subjects/lwcf/index.htm) according to federal law. However, these funds are subject to congressional appropriations. Actual annual appropriations to the fund have met the authorized threshold only twice (1998, 2001), while appropriations have been limited to between $255 million and $450 million since 2008.
-
-To see how much was disbursed to states, sub-funds, and other projects each year, see the following datasets.
-
-* [American Battlefield Protection Program, 2011-2015 data](/data/disbursements/lwcf/abpp.tsv) (TSV): Details about the location, acreage, and grant amounts of each battlefield funded through the [American Battlefield Protection Program](https://www.nps.gov/abpp/index.htm), a National Parks Service program that preserves the land where historic American battles were fought.
-
-* [Cooperative Endangered Species Conservation Fund, 2011-2015 data](/data/disbursements/lwcf/cescf.tsv) (TSV): List of individual projects and locations funded through the [Cooperative Endangered Species Conservation Fund](https://www.fws.gov/endangered/grants/), a [Fish and Wildlife Service](https://www.fws.gov/) program for conservation planning and acquisition of vital habitat for threatened and endangered species.
-
-* [State and local grants, 2011-2016 data](/data/disbursements/lwcf/grants.tsv) (TSV): Details about the location, amount, and purpose of all Land and Water Conservation Fund grants to state and local governments.
-
-* [Land acquisitions, 2011-2016 data](/data/disbursements/lwcf/land-acquisition.tsv) (TSV): Details about the location, budget, acreage, and purpose of each federal land acquisition funded by the Land and Water Conservation Fund.
-
-### Historic Preservation Fund
-
-Like the LWCF, money in the Historic Preservation Fund is subject to congressional appropriations. Some of it is spent on historic preservation projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $150 million each year, but annual appropriations have declined from $94 million to less than $60 million since 2001.
-
-To see how much was disbursed to each state for preservation projects, see [Historic Preservation grants, 2011-2016](/data/disbursements/historic-preservation.tsv) (TSV).
+_Total_ The total amount disbursed.
 
 ## Contact us
+Do you have questions about the data or need data that isn't here? Contact our data specialists at onrrdatarequests@onrr.gov.

--- a/src/markdown/downloads/disbursements.md
+++ b/src/markdown/downloads/disbursements.md
@@ -60,4 +60,3 @@ _County_ The county that received the disbursement in accordance with revenue-sh
 _Total_ The total amount disbursed.
 
 ## Contact us
-Do you have questions about the data or need data that isn't here? Contact our data specialists at onrrdatarequests@onrr.gov.

--- a/src/markdown/downloads/disbursements.md
+++ b/src/markdown/downloads/disbursements.md
@@ -45,7 +45,7 @@ _Fund Type_ The type of recipient receiving the disbursement.
 * _Land and Water Conservation_ Fund This fund provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states.
 * _Land and Water Conservation Fund GoMESA_ The Gulf of Mexico Energy Security Act (GOMESA) of 2006 specifies that 12.5% of revenues from certain gulf leases be directed to the LWCF stateside program. States can receive up to $125 million a year in funding. This portion of LWCF funds is not subject to the congressional appropriation process, but are otherwise treated similarly to regular LWCF funds.
 * _Historic Preservation Fund_ This fund helps preserve U.S. historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices.
-* _Reclamation_ Established by Congress in 1902 to pay for Bureau of Reclamation projects, this fund supports the establishment of critical infrastructure projects like dams and power plants.
+* _Reclamation Fund_ Established by Congress in 1902 to pay for Bureau of Reclamation projects, this fund supports the establishment of critical infrastructure projects like dams and power plants.
 * _State_ Funds disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.
 * _State 8(g)_ 27% of revenue from leases in the 8(g) Zone (the first three nautical miles of the Outer Continental Shelf) are shared with states.
 * _State GoMESA_ 37.5% of revenue from certain leases in the Gulf of Mexico are shared with Alabama, Louisiana, Mississippi, and Texas.


### PR DESCRIPTION
Adds definitions for disbursement monthly and yearly to be consistent with other download pages.

Fixes #4065 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/Update-disbursementdownload/)

Changes proposed in this pull request:

- updates disbursement by month download page
- updated disbursement by year download page
- Add fields and definitions
- Add different funds definitions to fund types
- Add list of commodities to disbursement by month data
