### PR TITLE
Fixes blog profile image distortion

### DIFF
--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -104,6 +104,8 @@ a:hover {
 
 .author-image {
   margin-bottom: 0;
+  margin-right: 0.725rem;
+  float: left;
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
@@ -164,5 +166,10 @@ a:hover {
   }
   .post-heading {
     font-size: 1.7rem;
+  }
+
+  .author-image {
+    display: flex;
+    float: none;
   }
 }

--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -106,12 +106,15 @@ a:hover {
   margin-right: 0.725rem;
 }
 
+.author-bio {
+  display: flex;
+}
+
 .author-image {
   margin-bottom: 0;
-  margin-right: 0.725rem;
-  float: left;
   width: 3rem;
   height: 3rem;
+  max-width: none;
   border-radius: 50%;
 }
 
@@ -175,9 +178,4 @@ a:hover {
   .author-bio {
     display: flex;
   }
-
-  .author-image {
-    max-width: none;
-  }
-
 }

--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -103,7 +103,6 @@ a:hover {
 /* Author profile */
 
 .author-image {
-  margin-right: 0.725rem;
   margin-bottom: 0;
   width: 3rem;
   height: 3rem;

--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -174,8 +174,4 @@ a:hover {
   .post-heading {
     font-size: 1.7rem;
   }
-
-  .author-bio {
-    display: flex;
-  }
 }

--- a/blog-site/src/components/layout.css
+++ b/blog-site/src/components/layout.css
@@ -102,6 +102,10 @@ a:hover {
 
 /* Author profile */
 
+.author-profile-container {
+  margin-right: 0.725rem;
+}
+
 .author-image {
   margin-bottom: 0;
   margin-right: 0.725rem;
@@ -168,8 +172,12 @@ a:hover {
     font-size: 1.7rem;
   }
 
-  .author-image {
+  .author-bio {
     display: flex;
-    float: none;
   }
+
+  .author-image {
+    max-width: none;
+  }
+
 }

--- a/blog-site/src/templates/blog-post.js
+++ b/blog-site/src/templates/blog-post.js
@@ -60,7 +60,9 @@ class BlogPostTemplate extends React.Component {
               display: 'flex',
             }}
           >
-           <div><img
+           <div style={{
+               marginRight: "0.725rem",
+           }}><img
                     src={author.pic}
                     alt={author.id + ` profile image`}
                     className="author-image"

--- a/blog-site/src/templates/blog-post.js
+++ b/blog-site/src/templates/blog-post.js
@@ -55,10 +55,9 @@ class BlogPostTemplate extends React.Component {
         
       {
         (post.frontmatter.authors).map((author, index) => (
-          <div key={index}>
-           <div style={{
-               marginRight: "0.725rem",
-           }}><img
+          <div key={index} className="author-bio">
+           <div className="author-profile-container">
+             <img
                     src={author.pic}
                     alt={author.id + ` profile image`}
                     className="author-image"

--- a/blog-site/src/templates/blog-post.js
+++ b/blog-site/src/templates/blog-post.js
@@ -55,11 +55,7 @@ class BlogPostTemplate extends React.Component {
         
       {
         (post.frontmatter.authors).map((author, index) => (
-          <div key={index}
-            style={{
-              display: 'flex',
-            }}
-          >
+          <div key={index}>
            <div style={{
                marginRight: "0.725rem",
            }}><img

--- a/blog-site/src/templates/blog-post.js
+++ b/blog-site/src/templates/blog-post.js
@@ -60,11 +60,12 @@ class BlogPostTemplate extends React.Component {
               display: 'flex',
             }}
           >
-            <img
+           <div><img
                     src={author.pic}
                     alt={author.id + ` profile image`}
                     className="author-image"
               />
+            </div>  
             <p
               style={{
                 marginRight: rhythm(1 / 2),


### PR DESCRIPTION
Fixes #4575 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-profile-image-fix/blog)

Changes proposed in this pull request:

- Restyles blog profile image to fix distortion in some browsers

## Production (Firefox)

![author images for Edward Chang and Ryan Johnson, with images distorted, squeezed width](https://user-images.githubusercontent.com/32855580/65457368-46297880-de00-11e9-897c-01533ef3a913.png)

## This PR (Firefox)

![author images for Edward Chang and Ryan Johnson, with images properly proportioned](https://user-images.githubusercontent.com/32855580/65457563-b1734a80-de00-11e9-82c2-9e9554b05655.png)

