### PR TITLE
Link to state top instead of revenue section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -174,7 +174,7 @@ class Beta extends React.Component {
 			mapJsonObject={{us:mapJson, offshore:mapOffshoreJson}}
 			onClick={ (d,i) => {
 			    let state=fipsAbbrev[d.id] || d.id;
-			    let url="/explore/"+state+"#revenue" 
+			    let url="/explore/"+state
 			    if(state.match(/offshore/)) {
 				url="/explore/"+state;
 			    }


### PR DESCRIPTION
Fixes #4507

[🗺 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/map-state-links/)

Changes proposed in this pull request:

- Directs choropleth map links to top of state and offshore pages (instead of `#revenue` section)
