### PR TITLE
added 10px to witdth of drop down to keep month from cutting off

### DIFF
--- a/src/components/sections/TotalRevenue/TotalRevenue.module.scss
+++ b/src/components/sections/TotalRevenue/TotalRevenue.module.scss
@@ -182,7 +182,7 @@
 .dropdown div:first-child{
 	display: inline-block;
 	margin-left: 10px;
-	width: 200px;
+	width: 210px;
 }
 
 .itemToggle .dropdown {


### PR DESCRIPTION
Fixes # 4504

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/4504-RevenueDropdown/)

Changes proposed in this pull request:

Made drop down wide enough to accommodate monthly options