### PR TITLE
Removes visual focus from selected tab to reconnect tab to content

### DIFF
--- a/src/components/layouts/Tabordion/Tabordion.module.scss
+++ b/src/components/layouts/Tabordion/Tabordion.module.scss
@@ -44,6 +44,7 @@ margin-top: 1rem;
 	padding-top: 6px;
 	font-weight: bold;
 	z-index: 20;
+	outline: none;
 
 	:last-of-type {
 		border-right: 1px solid --grayLight;


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/visual-focus/)

Changes proposed in this pull request:

- @mojobnichols has rendered our homepage tabs and charts keyboard accessible! This PR removes default _visual_ focus from the selected tab in order to reconnect it to the content it introduces.

_Note 1: Normally I wouldn't interfere with default browser focus styling, but the focus state for the selected tab disconnects it from the content, interfering with the visual continuity and purpose of the tabs themselves. The keyboard focus on inactive tabs is unaffected by this change._

_Note 2: This branch is sliced off @mojobnichols's branch (not `dev`), with the purpose of evaluating these changes separately from his work, while incorporating them into his changes. The destination is therefore his branch (not `dev`). (See #4606)_
