### PR TITLE
udpated civil penalties spelling

### DIFF
--- a/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
+++ b/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
@@ -121,16 +121,10 @@ const createRevenueNode = (revenueData, type) => {
       : (revenueNode.RevenueDate.getYear() + 1900).toString()
   }
 
-  let landCat = revenueNode.LandCategory && revenueNode.LandCategory.toLowerCase().trim()
-  let revType = revenueNode.RevenueType && revenueNode.RevenueType.toLowerCase().trim()
-
-  if (landCat === 'not tied to a lease' ||
-      revType === 'civil penalties' ||
-      revType === 'other revenues') {
-    if (revenueNode.LandClass !== CONSTANTS.NATIVE_AMERICAN &&
-        !revenueNode.OffshoreRegion) {
-      revenueNode.State = revenueNode.State || 'Not tied to a location'
-    }
+  if (revenueNode.LandClass === CONSTANTS.FEDERAL &&
+      !revenueNode.OffshoreRegion &&
+      !revenueNode.State) {
+    revenueNode.State = 'Not tied to a location'
   }
 
   return revenueNode
@@ -166,7 +160,5 @@ function getFipsCode (offshorePlanningArea) {
     return 'CHU'
   }
 
-
   return undefined
 }
-

--- a/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
+++ b/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
@@ -121,11 +121,12 @@ const createRevenueNode = (revenueData, type) => {
       : (revenueNode.RevenueDate.getYear() + 1900).toString()
   }
 
-  let landCat = revenueNode.LandCategory && revenueNode.LandCategory.toLowerCase()
+  let landCat = revenueNode.LandCategory && revenueNode.LandCategory.toLowerCase().trim()
+  let revType = revenueNode.RevenueType && revenueNode.RevenueType.toLowerCase().trim()
 
   if (landCat === 'not tied to a lease' ||
-     revenueNode.RevenueType === 'Civil Penalities' ||
-     revenueNode.RevenueType === 'Other Revenues') {
+      revType === 'civil penalties' ||
+      revType === 'other revenues') {
     if (revenueNode.LandClass !== CONSTANTS.NATIVE_AMERICAN &&
         !revenueNode.OffshoreRegion) {
       revenueNode.State = revenueNode.State || 'Not tied to a location'


### PR DESCRIPTION
Fixes #4596

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/onrr/doi-extractives-data/4596-revenue-table-not-tied-to-loc-fix/explore/revenue/)

Changes proposed in this pull request:

- Fixed spelling of Civil Penalties
-
-
