### PR TITLE
Moves skip-to-main id from section to main element

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -112,7 +112,7 @@ class Beta extends React.Component {
 	console.debug(mapJson);
 	return(
 	    <DefaultLayout>
-	      <main>
+	      <main id="main-content">
 		<Helmet
 		  title="Home | Natural Resources Revenue Data"
 		  meta={[
@@ -121,7 +121,7 @@ class Beta extends React.Component {
 		      { name: 'twitter:title', content: 'Home | Natural Resources Revenue Data' },
 		  ]} >
 		</Helmet>
-	        <section id="main-content" className="container-page-wrapper" >
+	        <section className="container-page-wrapper" >
 		<h3 className="h3-bar"></h3>
 		<p> When companies extract energy and mineral resources on property leased from the federal government and Native Americans, they pay <GlossaryTerm termKey="Bonus">bonuses</GlossaryTerm>, <GlossaryTerm>rent</GlossaryTerm>, and <GlossaryTerm termKey="Royalty">royalties</GlossaryTerm>. The Office of Natural Resources Revenue (ONRR) collects and <GlossaryTerm termKey="disbursement">disburses</GlossaryTerm> revenue from federal lands and waters to different agencies, funds, and local governments for public use. All revenue collected from extraction on Native American lands is disbursed to Native American tribes, nations, or individuals.</p>
 		</section>


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/move-main-id/)

Changes proposed in this pull request:

- Moves `main-content` `id` from `section` element to (more appropriate) `main` element on homepage
