### PR TITLE
Fixes GA and GTM implementations

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,7 @@ const BASEURL = process.env.BASEURL || undefined
 // Federalist provides the google_analytics env variable
 const GOOGLE_ANALYTICS_ID = (process.env.google_analytics)
   ? (process.env.google_analytics[process.env.BRANCH] || process.env.google_analytics.default)
-  : 'UA-48605964-8'
+  : 'UA-33523145-1'
 
 let config = {
   siteMetadata: {

--- a/src/components/layouts/DefaultLayout/DefaultLayout.js
+++ b/src/components/layouts/DefaultLayout/DefaultLayout.js
@@ -77,9 +77,7 @@ const DefaultLayout = ({ children }) => {
         <script>
           {"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-NCRF98R');"}
         </script>
-        <noscript>
-          {'<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NCRF98R" height="0" width="0" style="display:none;visibility:hidden"></iframe>'}
-        </noscript>
+        
       </Helmet>
 
       <a href="#main-content" className={styles.skipNav}>Skip to main content</a>  

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,47 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {/* <!-- Google Tag Manager (noscript) --> */}
+        <noscript dangerouslySetInnerHTML={{
+          __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NCRF98R" height="0" width="0"
+          style="display:none;visibility:hidden"></iframe>
+          `,
+        }}
+        />
+        {/* <!-- End Google Tag Manager (noscript) --> */}
+        {props.preBodyComponents}
+        <noscript key="noscript" id="gatsby-noscript">
+          This app works best with JavaScript enabled.
+        </noscript>
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}


### PR DESCRIPTION
Fixes/Updates #3672

[:sunglasses: REVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/3672-DeduplicateAnalyticsScripts/)

Updates made to this branch include:
- Remove all occurrences of old GA Id "UA-48605964-8"
- Move GTM noscript element from head element to right after body tag using [Gatsby's Custom Html Method](https://www.gatsbyjs.org/docs/custom-html/) per [Google's Tag Manager implementation Docs](https://developers.google.com/tag-manager/quickstart)

