### PR TITLE
Fixes accessibility issues from Pa11y on homepage

### DIFF
--- a/src/pages/explore/index.js
+++ b/src/pages/explore/index.js
@@ -144,7 +144,7 @@ class ExplorePage extends React.Component {
 
               <MobileNav navItems={NAV_ITEMS} navTitle={NAV_TITLE} />
 
-              <section id="production">
+              <section>
                 <h2 className="state-page-overview">Production</h2>
 
                 <NationalFederalProduction allProducts={this.props.data.FederalProductionByProduct.group} allYears={this.props.data.FederalProductionByYear.group}/>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -122,7 +122,7 @@ class Beta extends React.Component {
 		  ]} >
 		</Helmet>
 	  <section className="container-page-wrapper">
-      <span className="h3-bar">&nbsp;</span>
+      <span className="h3-bar"></span>
 		  <p> When companies extract energy and mineral resources on property leased from the federal government and Native Americans, they pay <GlossaryTerm termKey="Bonus">bonuses</GlossaryTerm>, <GlossaryTerm>rent</GlossaryTerm>, and <GlossaryTerm termKey="Royalty">royalties</GlossaryTerm>. The Office of Natural Resources Revenue (ONRR) collects and <GlossaryTerm termKey="disbursement">disburses</GlossaryTerm> revenue from federal lands and waters to different agencies, funds, and local governments for public use. All revenue collected from extraction on Native American lands is disbursed to Native American tribes, nations, or individuals.</p>
 		</section>
 		<Tabordion>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -121,9 +121,8 @@ class Beta extends React.Component {
 		      { name: 'twitter:title', content: 'Home | Natural Resources Revenue Data' },
 		  ]} >
 		</Helmet>
-	        <section className="container-page-wrapper" >
-		<h3 className="h3-bar"></h3>
-		<p> When companies extract energy and mineral resources on property leased from the federal government and Native Americans, they pay <GlossaryTerm termKey="Bonus">bonuses</GlossaryTerm>, <GlossaryTerm>rent</GlossaryTerm>, and <GlossaryTerm termKey="Royalty">royalties</GlossaryTerm>. The Office of Natural Resources Revenue (ONRR) collects and <GlossaryTerm termKey="disbursement">disburses</GlossaryTerm> revenue from federal lands and waters to different agencies, funds, and local governments for public use. All revenue collected from extraction on Native American lands is disbursed to Native American tribes, nations, or individuals.</p>
+	  <section className="container-page-wrapper">
+		  <p> When companies extract energy and mineral resources on property leased from the federal government and Native Americans, they pay <GlossaryTerm termKey="Bonus">bonuses</GlossaryTerm>, <GlossaryTerm>rent</GlossaryTerm>, and <GlossaryTerm termKey="Royalty">royalties</GlossaryTerm>. The Office of Natural Resources Revenue (ONRR) collects and <GlossaryTerm termKey="disbursement">disburses</GlossaryTerm> revenue from federal lands and waters to different agencies, funds, and local governments for public use. All revenue collected from extraction on Native American lands is disbursed to Native American tribes, nations, or individuals.</p>
 		</section>
 		<Tabordion>
 		<Tab id="tab-revenue" name="Revenue">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -122,6 +122,7 @@ class Beta extends React.Component {
 		  ]} >
 		</Helmet>
 	  <section className="container-page-wrapper">
+      <span className="h3-bar">&nbsp;</span>
 		  <p> When companies extract energy and mineral resources on property leased from the federal government and Native Americans, they pay <GlossaryTerm termKey="Bonus">bonuses</GlossaryTerm>, <GlossaryTerm>rent</GlossaryTerm>, and <GlossaryTerm termKey="Royalty">royalties</GlossaryTerm>. The Office of Natural Resources Revenue (ONRR) collects and <GlossaryTerm termKey="disbursement">disburses</GlossaryTerm> revenue from federal lands and waters to different agencies, funds, and local governments for public use. All revenue collected from extraction on Native American lands is disbursed to Native American tribes, nations, or individuals.</p>
 		</section>
 		<Tabordion>
@@ -540,5 +541,4 @@ const fipsAbbrev={
     "NOC":"offshore-pacific", 
     "SOC":"offshore-pacific",
     "WAO":"offshore-pacific"
-
 }

--- a/src/styles/elements/_typography.scss
+++ b/src/styles/elements/_typography.scss
@@ -52,6 +52,12 @@ h3,
   @include h3-bar;
 }
 
+span.h3-bar {
+  @include h3-bar;
+  display: inline-block;
+  width: 100%;
+}
+
 h4,
 .h4 {
   @include heading(h4);


### PR DESCRIPTION
Fixes #4068

[:sunglasses: REVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/4068-FixAccessibilityIssues/)

Updates made to this branch include:
- Remove the id attribute from the section element on home page/index page
- The id gets applied to the H2 element


Pa11y command for testing:

`pa11y --wait 1000 --debug https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/4068-FixAccessibilityIssues/`

Current response being seen in branch:

`Welcome to Pa11y`  
`Running Pa11y on URL https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/4068-FixAccessibilityIssues/`    
`Debug: Launching Headless Chrome`
`Debug: Opening URL in Headless Chrome`
`Debug: Browser Console: JSHandle@object mark`
`Debug: Loading runner: htmlcs`
`Debug: Injecting Pa11y`
`Debug: Injecting runner: htmlcs`
`Debug: Running Pa11y on the page`
`Debug: Waiting for 1000ms`
`Debug: Document title: "Home | Natural Resources Revenue Data"`

`No issues found!`

