### PR TITLE
Land and Water Conservation Fund authorization content updates

### DIFF
--- a/src/data/terms.yml
+++ b/src/data/terms.yml
@@ -12,6 +12,8 @@
   definition: "A yearly maintenance fee for maintaining a claim."
 - name: "APD"
   definition: "Application for permit to drill"
+- name: "Appropriation"
+  definition: "There are two main congressional actions that result in federal spending: authorization and appropriation. A fund or recipient may be authorized to receive money during the federal budget process, but Congress must still designate a specific amount to be distributed to the fund or recipient. This process is called "appropriation"."  
 - name: "Authorization"
   definition: "An act of Congress to obligate funding for a program or agency. An authorization may be effective for one year, a fixed number of years, or an indefinite period. An authorization may be for a definite amount of money or for 'such sums as may be necessary.' The formal federal spending process consists of two sequential steps: authorization and then appropriation."
 - name: "Barrel"

--- a/src/data/terms.yml
+++ b/src/data/terms.yml
@@ -13,7 +13,7 @@
 - name: "APD"
   definition: "Application for permit to drill"
 - name: "Appropriation"
-  definition: "There are two main congressional actions that result in federal spending: authorization and appropriation. A fund or recipient may be authorized to receive money during the federal budget process, but Congress must still designate a specific amount to be distributed to the fund or recipient. This process is called "appropriation"."  
+  definition: "There are two main congressional actions that result in federal spending: authorization and appropriation. A fund or recipient may be authorized to receive money during the federal budget process, but Congress must still designate a specific amount to be distributed to the fund or recipient. This process is called “appropriation”."  
 - name: "Authorization"
   definition: "An act of Congress to obligate funding for a program or agency. An authorization may be effective for one year, a fixed number of years, or an indefinite period. An authorization may be for a definite amount of money or for 'such sums as may be necessary.' The formal federal spending process consists of two sequential steps: authorization and then appropriation."
 - name: "Barrel"

--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -146,7 +146,7 @@ redirect_from: /how-it-works/production/
           </div>
           <div>
             <h4 class="h3 landing-heading"><custom-link to="/how-it-works/land-and-water-conservation-fund">Land and Water Conservation Fund</custom-link></h4>
-            <p>When <glossary-term termKey="authorization">authorized</glossary-term>, the Land and Water Conservation Fund receives disbursements from offshore oil and gas revenue to support conservation, outdoor recreation, and the needs of local communities.</p>
+            <p>The Land and Water Conservation Fund receives disbursements from offshore oil and gas revenue to support conservation, outdoor recreation, and the needs of local communities.</p>
             <p><custom-link to="/how-it-works/land-and-water-conservation-fund">Learn about the Land and Water Conservation Fund</custom-link></p>
           </div>
           <div>

--- a/src/markdown/how-it-works/lwcf.md
+++ b/src/markdown/how-it-works/lwcf.md
@@ -33,30 +33,10 @@ Depending on the agency or program, the LWCF supports:
 
 ## Authorization and funding
 
-<update-flag date="3/14/19"></update-flag>
-
 On March 12, 2019, the President signed into law the [John D. Dingell, Jr. Conservation, Management, and Recreation Act](https://www.congress.gov/bill/116th-congress/senate-bill/47) (formerly the Natural Resources Management Act). This bill reauthorizes the Land and Water Conservation Fund and also permanently <glossary-term termKey="authorization">authorizes</glossary-term> the fund, which means the fund no longer needs to be reauthorized by Congress in order to receive funding. Congress must still appropriate funds for the program each year during the annual budget process in order for the LWCF to receive funds.
 
-<update-flag date="2/28/19"></update-flag>
-
-The House of Representatives on Tuesday, February 26, 2019, passed the [Natural Resources Management Act](https://www.congress.gov/bill/116th-congress/senate-bill/47), part of which permanently <glossary-term termKey="authorization">authorizes</glossary-term> the Land and Water Conservation Fund. The bill now proceeds to the President to be signed into law.
-
-<update-flag date="2/14/19"></update-flag>
-
-The Senate on Tuesday, February 12, 2019, passed the [Natural Resources Management Act (PDF)](https://www.congress.gov/116/bills/s47/BILLS-116s47pcs.pdf), part of which permanently authorizes the Land and Water Conservation Fund.
-
-Permanent authorization of the LWCF means the fund would be authorized to receive and distribute designated revenue from offshore oil and gas production indefinitely. The annual amount of funding would still be subject to the annual budget process.
-
-The bill will now go to the House of Representatives where, if passed, it will proceed to the President for signature.
-
-<update-flag date="10/9/18"></update-flag>
-
-The LWCF was authorized through September 30, 2018. Congress did not reauthorize the fund before the end of the 2018 fiscal year. As a result, the requirement that a portion of offshore oil and gas revenues be deposited into the LWCF expired on October 1, 2018. The LWCF is not eligible to receive those disbursements unless Congress reauthorizes it. Congress may continue to appropriate revenues for LWCF-supported programs, if it so chooses.
-
-Lawmakers have [introduced bills in both the House and the Senate](https://www.congress.gov/search?q=%7B%22congress%22%3A%22115%22%2C%22source%22%3A%22legislation%22%2C%22search%22%3A%22%5C%22land%20and%20water%20conservation%20fund%5C%22%22%7D&searchResultViewType=expanded) to permanently authorize the fund.
-
 ### Annual funding
-The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue. When authorized, <glossary-term>ONRR</glossary-term> disburses that revenue to the fund each year.
+The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue. <glossary-term>ONRR</glossary-term> disburses that revenue to the fund each year.
 
 The LWCF is authorized to receive and distribute up to $900 million each year, but the fund is subject to congressional budget appropriations. Actual annual appropriations to the fund met the authorized threshold only twice (1998, 2001), while annual appropriations have been limited to between $255 million and $450 million since 2008.
 

--- a/src/markdown/how-it-works/lwcf.md
+++ b/src/markdown/how-it-works/lwcf.md
@@ -33,7 +33,7 @@ Depending on the agency or program, the LWCF supports:
 
 ## Authorization and funding
 
-On March 12, 2019, the President signed into law the [John D. Dingell, Jr. Conservation, Management, and Recreation Act](https://www.congress.gov/bill/116th-congress/senate-bill/47) (formerly the Natural Resources Management Act). This bill reauthorizes the Land and Water Conservation Fund and also permanently <glossary-term termKey="authorization">authorizes</glossary-term> the fund, which means the fund no longer needs to be reauthorized by Congress in order to receive funding. Congress must still appropriate funds for the program each year during the annual budget process in order for the LWCF to receive funds.
+On March 12, 2019, the President signed into law the [John D. Dingell, Jr. Conservation, Management, and Recreation Act](https://www.congress.gov/bill/116th-congress/senate-bill/47) (formerly the Natural Resources Management Act). This bill reauthorizes the Land and Water Conservation Fund and also permanently <glossary-term termKey="authorization">authorizes</glossary-term> the fund, which means the fund no longer needs to be reauthorized by Congress in order to receive funding. Congress must still <glossary-term termKey="appropriation">appropriate</glossary-term> funds for the program each year during the annual budget process in order for the LWCF to receive funds.
 
 ### Annual funding
 The fund doesn't receive any tax revenue, but is instead funded largely by offshore oil and gas revenue. <glossary-term>ONRR</glossary-term> disburses that revenue to the fund each year.

--- a/src/markdown/how-it-works/lwcf.md
+++ b/src/markdown/how-it-works/lwcf.md
@@ -17,7 +17,7 @@ tag:
 <custom-link to="/how-it-works/" className="breadcrumb link-charlie">How it works</custom-link> /
 # Land and Water Conservation Fund
 
-> The Land and Water Conservation Fund (LWCF) was enacted in 1964. It supports preservation, development, and access to outdoor lands for public recreation. The LWCF is funded by revenue from offshore oil and gas leases. 
+> Congress created the Land and Water Conservation Fund (LWCF) in 1964. The fund went into effect on January 1, 1965. It supports preservation, development, and access to outdoor lands for public recreation. The LWCF is funded by revenue from offshore oil and gas leases. 
 
 The [Land and Water Conservation Fund](https://www.nps.gov/subjects/lwcf/index.htm) provides competitive grants to states for local preservation and recreation projects, along with a federal portion to acquire lands and waters for public recreation or cultural resource preservation.
 


### PR DESCRIPTION
[🌲 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/lwcf-authorize/how-it-works/#disbursements)

Changes proposed in this pull request:

- Removes 'update' flags from LWCF content
- Removes references to 'when authorized,' since the fund is now permanently authorized
