### PR TITLE
Add CY to offshore pages 

### DIFF
--- a/src/components/locations/SectionOffshoreRevenue.js
+++ b/src/components/locations/SectionOffshoreRevenue.js
@@ -67,7 +67,7 @@ const SectionOffshoreRevenue = props => {
             </p>
             <p>
           The federal government collects different kinds of fees at each phase of resource extraction. This chart shows
-          how much federal revenue was collected in {commodityYearsSortDesc[0]} for production or potential production of natural resources on federal waters
+          how much federal revenue was collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> {commodityYearsSortDesc[0]} for production or potential production of natural resources on federal waters
           , broken down by phase of production.
             </p>
 		                <div id="fee-summaries" className="tab-interface">

--- a/src/components/locations/SectionOffshoreRevenue.js
+++ b/src/components/locations/SectionOffshoreRevenue.js
@@ -51,8 +51,7 @@ const SectionOffshoreRevenue = props => {
       <h2>Federal Revenue</h2>
 
       <p>Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue.</p>
-      <p>When companies extract natural resources on federal lands and waters, they pay royalties, rents, bonuses
-        , and other fees, much like they would to any landowner. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).</p>
+      <p>When companies extract natural resources on federal lands and waters, they pay royalties, rents, bonuses, and other fees, much like they would to any landowner. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).</p>
 
       <section id="federal-revenue">
 
@@ -67,8 +66,7 @@ const SectionOffshoreRevenue = props => {
             </p>
             <p>
           The federal government collects different kinds of fees at each phase of resource extraction. This chart shows
-          how much federal revenue was collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> {commodityYearsSortDesc[0]} for production or potential production of natural resources on federal waters
-          , broken down by phase of production.
+          how much federal revenue was collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> {commodityYearsSortDesc[0]} for production or potential production of natural resources on federal waters, broken down by phase of production.
             </p>
 		                <div id="fee-summaries" className="tab-interface">
 		                    <ul className="eiti-tabs info-tabs" role="tablist">

--- a/src/components/locations/SectionOffshoreRevenue.js
+++ b/src/components/locations/SectionOffshoreRevenue.js
@@ -5,6 +5,7 @@ import StickyHeader from '../layouts/StickyHeader'
 import { StickyWrapper } from '../utils/StickyWrapper'
 import YearSelector from '../selectors/YearSelector'
 import DataAndDocs from '../layouts/DataAndDocs'
+import GlossaryTerm from '../utils/glossary-term.js'
 import RevenueTypeTable from '../locations/RevenueTypeTable'
 import RevenueProcessTable from '../locations/RevenueProcessTable'
 import utils from '../../js/utils'
@@ -64,10 +65,7 @@ const SectionOffshoreRevenue = props => {
           . For details, read more about the processes for <Link to="/how-it-works/offshore-oil-gas/">offshore oil and gas
             </Link> or <Link to="/how-it-works/offshore-renewables/">offshore renewable energy</Link>.
             </p>
-            <p>
-          The federal government collects different kinds of fees at each phase of resource extraction. This chart shows
-          how much federal revenue was collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> {commodityYearsSortDesc[0]} for production or potential production of natural resources on federal waters, broken down by phase of production.
-            </p>
+            <p>The federal government collects different kinds of fees at each phase of resource extraction. This chart shows how much federal revenue was collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm> {commodityYearsSortDesc[0]} for production or potential production of natural resources on federal waters, broken down by phase of production.</p>
 		                <div id="fee-summaries" className="tab-interface">
 		                    <ul className="eiti-tabs info-tabs" role="tablist">
 		                        <li role="presentation">

--- a/src/components/locations/SectionRevenue.js
+++ b/src/components/locations/SectionRevenue.js
@@ -92,7 +92,7 @@ const SectionRevenue = props => {
               , <Link to="/how-it-works/onshore-renewables/">renewable resources</Link>, and <Link to="/how-it-works/minerals/">hardrock minerals</Link>.</p>
 
             <p>The federal government collects different kinds of fees at each phase of natural resource extraction
-              . This chart shows how much federal revenue was collected in <GlossaryTerm>Calendar year (CY)</GlossaryTerm>
+              . This chart shows how much federal revenue was collected in <GlossaryTerm>calendar year (CY)</GlossaryTerm>
             { commodityYearsSortDesc[0] } for production or potential production of natural resources on federal land in
             { " "+usStateData.title }, broken down by phase of production.</p>
 


### PR DESCRIPTION
Fixes #4532

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/offshore_update/)

Changes proposed in this pull request:

- adds CY to offshore revenue pages in explore data to clarify that the data is calendar year
- changes Calendar year to calendar year in onshore revenue pages 