### PR TITLE
Increase max old space size gatsby build and develop scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   "license": "MIT",
   "scripts": {
     "clean": "gatsby clean",
-    "build": "NODE_OPTIONS=--max_old_space_size=4096 gatsby build --prefix-paths",
-    "develop": "NODE_OPTIONS=--max_old_space_size=4096 gatsby develop --prefix-paths",
+    "build": "NODE_OPTIONS=--max_old_space_size=8192 gatsby build --prefix-paths",
+    "develop": "NODE_OPTIONS=--max_old_space_size=8192 gatsby develop --prefix-paths",
     "serve": "gatsby serve",
     "format": "eslint --fix 'src/**'",
     "test": "jest",


### PR DESCRIPTION
Fixes #4676

Updates to this branch include:

- updating the NODE_OPTIONS, "max_old_space_size" from 4096 to 8192