### PR TITLE
Add "Not tied to lease" category to homepage revenue graph

### DIFF
--- a/src/components/charts/ChartLegend_README.md
+++ b/src/components/charts/ChartLegend_README.md
@@ -12,7 +12,7 @@ The Chart Legend is legendary. Ryan and/or Shannon please add a description.
 
 ## How to use
 
-The legend can be used with any chart to display the values of each fo the data poitns with a calculated sum for the total. 
+The legend can be used with any chart to display the values of each of the data points with a calculated sum for the total. 
 
 ### Chart Data:
 This is an array of objects that will be used to populate the legend

--- a/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
+++ b/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
@@ -1,93 +1,119 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import MediaQuery from 'react-responsive'
+import React from "react";
+import PropTypes from "prop-types";
+import MediaQuery from "react-responsive";
 
-import styles from './StackedBarChartLayout.module.scss'
+import styles from "./StackedBarChartLayout.module.scss";
 
-import { ChartTitle } from '../../../charts/ChartTitle'
-import { StackedBarChart } from '../../../charts/StackedBarChart'
-import { ChartLegendStandard } from '../../../charts/ChartLegendStandard'
-import { Accordion } from '../../Accordion'
+import { ChartTitle } from "../../../charts/ChartTitle";
+import { StackedBarChart } from "../../../charts/StackedBarChart";
+import { ChartLegendStandard } from "../../../charts/ChartLegendStandard";
+import { Accordion } from "../../Accordion";
 
-import utils from '../../../../js/utils'
+import utils from "../../../../js/utils";
 
-const MAX_CHART_BAR_SIZE = 15
+const MAX_CHART_BAR_SIZE = 15;
 
 class StackedBarChartLayout extends React.Component {
   state = {
     dataSet: this.props.dataSet,
-    barHovered: this.props.barHovered,
+    barHovered: this.props.barHovered
+  };
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ dataSet: nextProps.dataSet, barHovered: undefined });
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.setState({ dataSet: nextProps.dataSet, barHovered: undefined })
-  }
-
-  shouldComponentUpdate (nextProps, nextState) {
+  shouldComponentUpdate(nextProps, nextState) {
     return (
-      (this.state.dataSet !== undefined && (this.state.dataSet.lastUpdated !== nextProps.dataSet.lastUpdated)) ||
-      (this.state.barHovered !== nextState.barHovered) ||
-      (this.state.dataSet.selectedDataKey !== nextProps.dataSet.selectedDataKey)
-    )
+      (this.state.dataSet !== undefined &&
+        this.state.dataSet.lastUpdated !== nextProps.dataSet.lastUpdated) ||
+      this.state.barHovered !== nextState.barHovered ||
+      this.state.dataSet.selectedDataKey !== nextProps.dataSet.selectedDataKey
+    );
   }
 
-  barHoveredCallback (data, isHover) {
+  barHoveredCallback(data, isHover) {
     if (isHover) {
-      this.setState({ barHovered: data })
-    }
-    else {
-      this.setState({ barHovered: undefined })
+      this.setState({ barHovered: data });
+    } else {
+      this.setState({ barHovered: undefined });
     }
   }
 
-  getStyleMap () {
-    return (this.state.chartDataKeyHovered &&
-        (this.props.chartDisplayConfig.styleMap && this.props.chartDisplayConfig.styleMap.hover))
-      ? this.props.chartDisplayConfig.styleMap.hover : this.props.chartDisplayConfig.styleMap
+  getStyleMap() {
+    return this.state.chartDataKeyHovered &&
+      (this.props.chartDisplayConfig.styleMap &&
+        this.props.chartDisplayConfig.styleMap.hover)
+      ? this.props.chartDisplayConfig.styleMap.hover
+      : this.props.chartDisplayConfig.styleMap;
   }
 
-  getChartLegend () {
-      let { legendTitle, legendDataFormatFunc, sortOrder, styleMap, showUnits } = this.props
-    let { data, legendLabels, selectedDataKey, units } = this.state.dataSet
-    let legendData
+  getChartLegend() {
+    let {
+      legendTitle,
+      legendDataFormatFunc,
+      sortOrder,
+      styleMap,
+      showUnits
+    } = this.props;
+    let { data, legendLabels, selectedDataKey, units } = this.state.dataSet;
+    let legendData;
     if (this.state.barHovered) {
-      selectedDataKey = Object.keys(this.state.barHovered)[0]
-      legendData = this.state.barHovered[selectedDataKey][0]
-      styleMap = styleMap.hover
+      selectedDataKey = Object.keys(this.state.barHovered)[0];
+      legendData = this.state.barHovered[selectedDataKey][0];
+      styleMap = styleMap.hover;
+    } else {
+      let selectedData = data.find(
+        dataItem => Object.keys(dataItem)[0] === selectedDataKey
+      );
+      legendData = selectedData && selectedData[selectedDataKey][0];
     }
-    else {
-      let selectedData = data.find(dataItem => Object.keys(dataItem)[0] === selectedDataKey)
-      legendData = selectedData && selectedData[selectedDataKey][0]
+    let unitsForValues = "";
+    if (showUnits) {
+      unitsForValues = " (" + units + ")";
     }
-      let unitsForValues='';
-      if(showUnits) {
-	  unitsForValues=' ('+units+')';
-      }
+
     return (
       <ChartLegendStandard
         headerName={legendTitle}
-        headerNameForValues={(legendLabels && legendLabels[selectedDataKey]) +unitsForValues }
+        headerNameForValues={
+          (legendLabels && legendLabels[selectedDataKey]) + unitsForValues
+        }
         data={legendData}
         dataFormatFunc={legendDataFormatFunc}
         styleMap={styleMap}
         sortOrder={sortOrder}
-        units={units} >
-      </ChartLegendStandard>
-    )
+        units={units}
+      ></ChartLegendStandard>
+    );
   }
 
-  render () {
-      let { title, sortOrder, styleMap, barSelectedCallback, showUnits } = this.props
-    let { data, selectedDataKey, groupNames, longUnits, xAxisLabels } = this.state.dataSet
-      let titleUnits='';
-      if(showUnits) {
-	  titleUnits=' ('+longUnits+')';
-      }
+  render() {
+    let {
+      title,
+      sortOrder,
+      styleMap,
+      barSelectedCallback,
+      showUnits
+    } = this.props;
+    let {
+      data,
+      selectedDataKey,
+      groupNames,
+      longUnits,
+      xAxisLabels
+    } = this.state.dataSet;
+    let titleUnits = "";
+    if (showUnits) {
+      titleUnits = " (" + longUnits + ")";
+    }
     return (
       <div className={styles.root}>
-            <ChartTitle>{title} {titleUnits}</ChartTitle>
+        <ChartTitle>
+          {title} {titleUnits}
+        </ChartTitle>
 
-        {this.state.dataSet &&
+        {this.state.dataSet && (
           <div>
             <div className={styles.chart}>
               <StackedBarChart
@@ -103,19 +129,19 @@ class StackedBarChartLayout extends React.Component {
                 xAxisLabels={xAxisLabels}
               />
             </div>
-            <MediaQuery minWidth={769}>
-              {this.getChartLegend()}
-            </MediaQuery>
+            <MediaQuery minWidth={769}>{this.getChartLegend()}</MediaQuery>
             <MediaQuery maxWidth={768}>
-              <Accordion id={utils.formatToSlug(title)} text={['Show details', 'Hide details']}>
+              <Accordion
+                id={utils.formatToSlug(title)}
+                text={["Show details", "Hide details"]}
+              >
                 {this.getChartLegend()}
               </Accordion>
             </MediaQuery>
           </div>
-        }
-
+        )}
       </div>
-    )
+    );
   }
 }
 
@@ -128,11 +154,10 @@ StackedBarChartLayout.propTypes = {
   styleMap: PropTypes.object,
   /** This object holds all the related information for the dataSet.
     It also provides a LastUpdated property to verify this component should update. */
-  dataSet: PropTypes.object,
+  dataSet: PropTypes.object
+};
 
-}
-
-export default StackedBarChartLayout
+export default StackedBarChartLayout;
 
 /*
 

--- a/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
+++ b/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
@@ -49,12 +49,14 @@ class StackedBarChartLayout extends React.Component {
   }
 
   getChartLegend() {
+    console.log('this.props: ', this.props)
     let {
       legendTitle,
       legendDataFormatFunc,
       sortOrder,
       styleMap,
-      showUnits
+      showUnits,
+      displayNames
     } = this.props;
     let { data, legendLabels, selectedDataKey, units } = this.state.dataSet;
     let legendData;
@@ -84,6 +86,7 @@ class StackedBarChartLayout extends React.Component {
         styleMap={styleMap}
         sortOrder={sortOrder}
         units={units}
+        displayNames={displayNames}
       ></ChartLegendStandard>
     );
   }

--- a/src/components/sections/TotalDisbursements/TotalDisbursements.module.scss
+++ b/src/components/sections/TotalDisbursements/TotalDisbursements.module.scss
@@ -1,14 +1,14 @@
 @value colors: "../../../css-global/colors.scss";
-@value grayBlueDark as _grayBlueDark, grayBlueMid as _grayBlueMid, grayMidLight as _grayMidLight, grayBlueMidLight as _grayBlueMidLight from colors;
-@value blueMidLight as _blueMidLight, blueMid as _blueMid, blueDark as _blueDark from colors;
+@value black as _black, grayBlueDark as _grayBlueDark, grayBlueMid as _grayBlueMid, grayMidLight as _grayMidLight, grayBlueMidLight as _grayBlueMidLight from colors;
+@value blueMidLight as _blueMidLight, blueMid as _blueMid, blueDark as _blueDark, blueDarkest as _blueDarkest from colors;
 @value greenLight as _greenLight, blueMid as _blueMid, blueDark as _blueDark from colors;
 
-@value federalOffshoreColor: _grayBlueMid;
-@value federalOnshoreColor: _grayBlueDark;
-@value nativeAmericanColor: _grayBlueMidLight;
-@value federalOffshoreColor_selected: _blueMid;
-@value federalOnshoreColor_selected: _blueDark;
-@value nativeAmericanColor_selected: _blueMidLight;
+@value federalOffshoreColor: _grayBlueDark;
+@value federalOnshoreColor: _black;
+@value nativeAmericanColor: _grayBlueMid;
+@value federalOffshoreColor_selected: _blueDark;
+@value federalOnshoreColor_selected: _blueDarkest;
+@value nativeAmericanColor_selected: _blueMid;
 
 .root{}
 .title {

--- a/src/components/sections/TotalDisbursements/TotalDisbursements.module.scss
+++ b/src/components/sections/TotalDisbursements/TotalDisbursements.module.scss
@@ -6,8 +6,9 @@
 @value federalOffshoreColor: _grayBlueDark;
 @value federalOnshoreColor: _black;
 @value nativeAmericanColor: _grayBlueMid;
+
 @value federalOffshoreColor_selected: _blueDark;
-@value federalOnshoreColor_selected: _blueDarkest;
+@value federalOnshoreColor_selected: _black;
 @value nativeAmericanColor_selected: _blueMid;
 
 .root{}

--- a/src/components/sections/TotalProduction/TotalProduction.module.scss
+++ b/src/components/sections/TotalProduction/TotalProduction.module.scss
@@ -1,14 +1,14 @@
 @value colors: "../../../css-global/colors.scss";
 @value grayBlueDark as _grayBlueDark, grayBlueMid as _grayBlueMid, grayMidLight as _grayMidLight, grayBlueMidLight as _grayBlueMidLight from colors;
-@value blueMidLight as _blueMidLight, blueMid as _blueMid, blueDark as _blueDark from colors;
+@value black as _black, blueMidLight as _blueMidLight, blueMid as _blueMid, blueDark as _blueDark, blueDarkest as _blueDarkest from colors;
 @value greenLight as _greenLight, blueMid as _blueMid, blueDark as _blueDark from colors;
 
-@value federalOffshoreColor: _grayBlueMid;
-@value federalOnshoreColor: _grayBlueDark;
-@value nativeAmericanColor: _grayBlueMidLight;
-@value federalOffshoreColor_selected: _blueMid;
-@value federalOnshoreColor_selected: _blueDark;
-@value nativeAmericanColor_selected: _blueMidLight;
+@value federalOffshoreColor: _grayBlueDark;
+@value federalOnshoreColor: _black;
+@value nativeAmericanColor: _grayBlueMid;
+@value federalOffshoreColor_selected: _blueDark;
+@value federalOnshoreColor_selected: _blueDarkest;
+@value nativeAmericanColor_selected: _blueMid;
 
 .root{}
 

--- a/src/components/sections/TotalProduction/TotalProduction.module.scss
+++ b/src/components/sections/TotalProduction/TotalProduction.module.scss
@@ -7,7 +7,7 @@
 @value federalOnshoreColor: _black;
 @value nativeAmericanColor: _grayBlueMid;
 @value federalOffshoreColor_selected: _blueDark;
-@value federalOnshoreColor_selected: _blueDarkest;
+@value federalOnshoreColor_selected: _black;
 @value nativeAmericanColor_selected: _blueMid;
 
 .root{}

--- a/src/components/sections/TotalRevenue/TotalRevenue.module.scss
+++ b/src/components/sections/TotalRevenue/TotalRevenue.module.scss
@@ -17,7 +17,7 @@
 @value notTiedToALeaseColor: _grayBlueMidLight;
 
 @value federalOffshoreColor_selected: _blueDark;
-@value federalOnshoreColor_selected: _blueDarkest;
+@value federalOnshoreColor_selected: _black;
 @value nativeAmericanColor_selected: _blueMid;
 @value notTiedToALeaseColor_selected: _blueMidLight;
 

--- a/src/components/sections/TotalRevenue/TotalRevenue.module.scss
+++ b/src/components/sections/TotalRevenue/TotalRevenue.module.scss
@@ -1,14 +1,25 @@
 @value colors: "../../../css-global/colors.scss";
-@value grayBlueDark as _grayBlueDark, grayBlueMid as _grayBlueMid, grayMidLight as _grayMidLight, grayBlueMidLight as _grayBlueMidLight from colors;
-@value blueMidLight as _blueMidLight, blueMid as _blueMid, blueDark as _blueDark from colors;
-@value greenLight as _greenLight, blueMid as _blueMid, blueDark as _blueDark from colors;
+
+// Grays
+@value black as _black, grayBlueDark as _grayBlueDark, grayBlueMid as _grayBlueMid, grayMidLight as _grayMidLight, grayBlueMidLight as _grayBlueMidLight, grayBlueLight as _grayBlueLight from colors;
+
+// Blues
+@value blueLighter as _blueLighter, blueLight as _blueLight, blueMidLight as _blueMidLight, blueCthru as _blueCthru, blueMid as _blueMid from colors;
+@value blueMidDark as _blueMideDark, blue as _blueDark, blueDark as _blueDark, blueDarker as _blueDarker, blueDeep as _blueDeep, blueDarkest as _blueDarkest from colors;
+
+// Greens
+@value greenLight as _greenLight from colors;
 
 @value federalOffshoreColor: _grayBlueMid;
-@value federalOnshoreColor: _grayBlueDark;
+@value federalOnshoreColor: _black;
 @value nativeAmericanColor: _grayBlueMidLight;
-@value federalOffshoreColor_selected: _blueMid;
-@value federalOnshoreColor_selected: _blueDark;
-@value nativeAmericanColor_selected: _blueMidLight;
+@value notTiedToALeaseColor: _grayBlueMidLight;
+
+@value federalOffshoreColor_selected: _blueDark;
+@value federalOnshoreColor_selected: _blueDarkest;
+@value nativeAmericanColor_selected: _blueMid;
+@value notTiedToALeaseColor_selected: _blueMidLight;
+
 
 .root{}
 .title {
@@ -49,29 +60,42 @@
 	fill: nativeAmericanColor;
 }
 
+.notTiedToALease {
+	background-color: notTiedToALeaseColor_selected;
+	fill: notTiedToALeaseColor;
+}
 
 
-.chartBar[selected=true] .federalOnshore{
+
+.chartBar[selected=true] .federalOnshore {
 	fill: federalOnshoreColor_selected;
 }
-.chartBar[selected=true] .federalOffshore{
+.chartBar[selected=true] .federalOffshore {
 	fill: federalOffshoreColor_selected;
 }
-.chartBar[selected=true] .nativeAmerican{
+.chartBar[selected=true] .nativeAmerican {
 	fill: nativeAmericanColor_selected;
 }
+.chartBar[selected=true] .notTiedToALease {
+	fill: notTiedToALease_selected;
+}
 
-.chartBar:hover .federalOnshore{
+.chartBar:hover .federalOnshore {
 	fill: federalOnshoreColor_selected;
 	opacity: 0.8;
 }
 
-.chartBar:hover .federalOffshore{
+.chartBar:hover .federalOffshore {
 	fill: federalOffshoreColor_selected;
 	opacity: 0.8;
 }
-.chartBar:hover .nativeAmerican{
+.chartBar:hover .nativeAmerican {
 	fill: nativeAmericanColor_selected;
+	opacity: 0.8;
+}
+
+.chartBar:hover .notTiedToALease {
+	fill: notTiedToALease_selected;
 	opacity: 0.8;
 }
 
@@ -85,6 +109,11 @@
 }
 .nativeAmericanHover {
 	background-color: nativeAmericanColor_selected;
+	opacity: 0.8;
+}
+
+.notTiedToALeaseHover {
+	background-color: notTiedToALeaseColor_selected;
 	opacity: 0.8;
 }
 

--- a/src/components/sections/TotalRevenue/TotalRevenue.module.scss
+++ b/src/components/sections/TotalRevenue/TotalRevenue.module.scss
@@ -1,7 +1,8 @@
 @value colors: "../../../css-global/colors.scss";
 
 // Grays
-@value black as _black, grayBlueDark as _grayBlueDark, grayBlueMid as _grayBlueMid, grayMidLight as _grayMidLight, grayBlueMidLight as _grayBlueMidLight, grayBlueLight as _grayBlueLight from colors;
+@value black as _black, grayBlueDark as _grayBlueDark, grayBlueMid as _grayBlueMid, grayMidLight as _grayMidLight from colors;
+@value grayBlueMidLight as _grayBlueMidLight, grayBlueLight as _grayBlueLight from colors;
 
 // Blues
 @value blueLighter as _blueLighter, blueLight as _blueLight, blueMidLight as _blueMidLight, blueCthru as _blueCthru, blueMid as _blueMid from colors;
@@ -10,9 +11,9 @@
 // Greens
 @value greenLight as _greenLight from colors;
 
-@value federalOffshoreColor: _grayBlueMid;
+@value federalOffshoreColor: _grayBlueDark;
 @value federalOnshoreColor: _black;
-@value nativeAmericanColor: _grayBlueMidLight;
+@value nativeAmericanColor: _grayBlueMid;
 @value notTiedToALeaseColor: _grayBlueMidLight;
 
 @value federalOffshoreColor_selected: _blueDark;
@@ -59,7 +60,6 @@
 	background-color: nativeAmericanColor_selected;
 	fill: nativeAmericanColor;
 }
-
 .notTiedToALease {
 	background-color: notTiedToALeaseColor_selected;
 	fill: notTiedToALeaseColor;

--- a/src/components/sections/TotalRevenue/TotalRevenueDeprecated.js
+++ b/src/components/sections/TotalRevenue/TotalRevenueDeprecated.js
@@ -48,17 +48,19 @@ const YEARLY_DROPDOWN_VALUES = {
 
 const CHART_LEGEND_TITLE = 'Source'
 
-const CHART_SORT_ORDER = [CONSTANTS.FEDERAL_ONSHORE, CONSTANTS.FEDERAL_OFFSHORE, CONSTANTS.NATIVE_AMERICAN]
+const CHART_SORT_ORDER = [CONSTANTS.FEDERAL_ONSHORE, CONSTANTS.FEDERAL_OFFSHORE, CONSTANTS.NATIVE_AMERICAN, CONSTANTS.NOT_TIED_TO_A_LEASE]
 
 const CHART_STYLE_MAP = {
   'bar': styles.chartBar,
   [CONSTANTS.FEDERAL_OFFSHORE]: styles.federalOffshore,
   [CONSTANTS.FEDERAL_ONSHORE]: styles.federalOnshore,
-  [CONSTANTS.NATIVE_AMERICAN]: styles.nativeAmerican,
+	[CONSTANTS.NATIVE_AMERICAN]: styles.nativeAmerican,
+	[CONSTANTS.NOT_TIED_TO_A_LEASE]: styles.notTiedToALease,
   hover: {
     [CONSTANTS.FEDERAL_OFFSHORE]: styles.federalOffshoreHover,
     [CONSTANTS.FEDERAL_ONSHORE]: styles.federalOnshoreHover,
-    [CONSTANTS.NATIVE_AMERICAN]: styles.nativeAmericanHover,
+		[CONSTANTS.NATIVE_AMERICAN]: styles.nativeAmericanHover,
+		[CONSTANTS.NOT_TIED_TO_A_LEASE]: styles.notTiedToALeaseHover
   }
 }
 
@@ -339,7 +341,7 @@ class TotalRevenueDeprecated extends React.Component {
 	  return (
 		  <section className={styles.revenueDisbursementsSection} >
 		  
-		  <h3 className={styles.title+" h3-bar"}>Total revenue<span className={styles.titleRight}>
+		  <h3 className={styles.title+" h3-bar"}>Total Revenue<span className={styles.titleRight}>
 		  <ExploreDataLink
 		    to="/explore/revenue"
 	            icon="filter"      

--- a/src/components/sections/TotalRevenue/TotalRevenueDeprecated.js
+++ b/src/components/sections/TotalRevenue/TotalRevenueDeprecated.js
@@ -50,6 +50,9 @@ const CHART_LEGEND_TITLE = 'Source'
 
 const CHART_SORT_ORDER = [CONSTANTS.FEDERAL_ONSHORE, CONSTANTS.FEDERAL_OFFSHORE, CONSTANTS.NATIVE_AMERICAN, CONSTANTS.NOT_TIED_TO_A_LEASE]
 
+const CHART_DISPLAY_NAMES = {}
+CHART_DISPLAY_NAMES[CONSTANTS.NOT_TIED_TO_A_LEASE] = {displayName: 'Federal - Not tied to a lease'}
+
 const CHART_STYLE_MAP = {
   'bar': styles.chartBar,
   [CONSTANTS.FEDERAL_OFFSHORE]: styles.federalOffshore,
@@ -320,7 +323,9 @@ class TotalRevenueDeprecated extends React.Component {
 
 	        sortOrder= {CHART_SORT_ORDER}
 
-	        legendTitle= {CHART_LEGEND_TITLE}
+					legendTitle= {CHART_LEGEND_TITLE}
+					
+					displayNames= {CHART_DISPLAY_NAMES}
 
 	        legendDataFormatFunc= {dataFormatFunc || utils.formatToCommaInt}
 

--- a/src/css-global/colors.scss
+++ b/src/css-global/colors.scss
@@ -32,6 +32,7 @@
 	blueDark: #086996; /* darker link color for use over @value blue-cthru, for accessibility */
 	blueDarker: #005078;
 	blueDeep: #00354f;
+	blueDarkest: #032435;
 
 	/* Reds */
 	red: #c5403c;

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -27,6 +27,7 @@ module.exports = Object.freeze({
   FEDERAL_OFFSHORE: 'Federal offshore',
   FEDERAL_ONSHORE: 'Federal onshore',
   NATIVE_AMERICAN: 'Native American',
+  NOT_TIED_TO_A_LEASE: 'Not tied to a lease',
   OFFSHORE: 'Offshore',
   ONSHORE: 'Onshore',
   FEDERAL: 'Federal',


### PR DESCRIPTION
Fixes #3929

[preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/onrr/doi-extractives-data/3929-ConsiderAddingNotTiedToALocation/)

Changes proposed in this pull request:

- Adds "Not tied to a lease" data row to homepage Total Revenue Table
- Adjusts color range for each source
