### PR TITLE
Fy disbursement file size fix

### DIFF
--- a/src/markdown/downloads/disbursements.md
+++ b/src/markdown/downloads/disbursements.md
@@ -24,7 +24,7 @@ Download fiscal year data:
 
 ## Scope
 
-This dataset includes natural resource disbursements for U.S. federal lands, federal offshore areas, and Native American lands. It does not include privately owned lands or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. It contains disbursement information to funds for fiscal years 2003-2018. Disbursements of revenue from extractive activities on U.S. federal lands occur monthly; this dataset is a sum of those disbursements by fiscal year.
+This dataset includes natural resource disbursements for U.S. federal lands, federal offshore areas, and Native American lands. It does not include privately owned lands or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. It contains disbursement information to funds for fiscal years 2003-2019. Disbursements of revenue from extractive activities on U.S. federal lands occur monthly; this dataset is a sum of those disbursements by fiscal year.
 
 ## Data publication
 

--- a/src/markdown/downloads/disbursements.md
+++ b/src/markdown/downloads/disbursements.md
@@ -18,7 +18,7 @@ tag:
 Download fiscal year data:
 
 <ul class="downloads-download_links list-unstyled">
-  <li><excel-link to="/downloads/disbursements/disbursements.xlsx">Fiscal year disbursements (Excel, 64 KB)</excel-link></li>
+  <li><excel-link to="/downloads/disbursements/disbursements.xlsx">Fiscal year disbursements (Excel, 84 KB)</excel-link></li>
   <li><csv-link to="/downloads/csv/disbursements/disbursements.csv">Fiscal year disbursements (csv, 83 KB)</csv-link></li>
 </ul>
 


### PR DESCRIPTION
Fixes #4754 #4756 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fy_disbursement_file_size_fix/)

Changes proposed in this pull request:

-fixes scope language to include 2019
-Edits file size from 64kb to 84kb
-
