### PR TITLE
Option to add CY and FY to state page intro lines

### DIFF
--- a/src/components/locations/SectionOverview.js
+++ b/src/components/locations/SectionOverview.js
@@ -187,11 +187,11 @@ console.log(commodityCurrentYear);
 
   return (
     <div>
-        {commodityCount === 1 && <p><strong>{commodityCount}</strong> energy or mineral commodity was produced on federal land in {props.stateName} in {currentYear}.</p>}
+        {commodityCount === 1 && <p><strong>{commodityCount}</strong> energy or mineral commodity was produced on federal land in {props.stateName} in <GlossaryTerm>calendar year</GlossaryTerm> {currentYear}.</p>}
         
-        {commodityCount > 1 && <p><strong>{commodityCount}</strong> energy or mineral commodities were produced on federal land in {props.stateName} in {currentYear}.</p>}
+        {commodityCount > 1 && <p><strong>{commodityCount}</strong> energy or mineral commodities were produced on federal land in {props.stateName} in <GlossaryTerm>calendar year</GlossaryTerm>  {currentYear}.</p>}
 
-        {commodityCount === 0 && <p>There was no energy or mineral production on federal land in {props.stateName} in {currentYear}.</p>}
+        {commodityCount === 0 && <p>There was no energy or mineral production on federal land in {props.stateName} in <GlossaryTerm>calendar year</GlossaryTerm> {currentYear}.</p>}
 
         {withhelds.length === 1 && <em><strong>{withhelds.length}</strong> commodity was <GlossaryTerm>withheld</GlossaryTerm> in {currentYear}.</em>}
         
@@ -209,7 +209,7 @@ const revenue = props.revenue.All.All[revenueYear]
 
   return (
     <div>
-      <p>Production on federal land in {props.stateName} resulted in <strong>{utils.formatToDollarInt(revenue)}</strong> in {revenueYear} revenue.</p>
+      <p>Production on federal land in {props.stateName} resulted in <strong>{utils.formatToDollarInt(revenue)}</strong> in <GlossaryTerm>calendar year</GlossaryTerm> {revenueYear} revenue.</p>
       <hr></hr>
     </div>
   )
@@ -223,9 +223,9 @@ const StateDisbursementsSummary = props => {
     
     return (
 	    <div>
-	    { allDisbursements > 0 && <p>Revenue from federal land resulted in <strong> {utils.formatToDollarInt(allDisbursements)}</strong> disbursed from the federal government to {stateName} in {maxYear}.</p> }
+	    { allDisbursements > 0 && <p>Revenue from federal land resulted in <strong> {utils.formatToDollarInt(allDisbursements)}</strong> disbursed from the federal government to {stateName} in <GlossaryTerm>fiscal year</GlossaryTerm> {maxYear}.</p> }
 
-      { (allDisbursements == null || allDisbursements == 0 ) && <p>No disbursements were reported for {stateName} in {maxYear}, probably because there was no revenue from production on federal land.</p> }
+      { (allDisbursements == null || allDisbursements == 0 ) && <p>No disbursements were reported for {stateName} in <GlossaryTerm>fiscal year</GlossaryTerm> {maxYear}, probably because there was no revenue from production on federal land.</p> }
       <hr></hr>
 	    </div>
   )


### PR DESCRIPTION
[🐢 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/add-fy-and-cy/explore/WY)

Changes proposed in this pull request:

- Adds CY and FY labels to state page intro data points
