### PR TITLE
Add description to blog graphql query

### DIFF
--- a/blog-site/src/templates/blog-list.js
+++ b/blog-site/src/templates/blog-list.js
@@ -122,6 +122,7 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
+        description
       }
     }
     allMarkdownRemark(


### PR DESCRIPTION
Fixes #4767

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/4767-so-meta/blog)

Changes proposed in this pull request:

- Adds query for `meta` description to fix SEO shortcoming
