### PR TITLE
"Fixes" double production units on homepage tab

### DIFF
--- a/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
+++ b/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
@@ -106,14 +106,11 @@ class StackedBarChartLayout extends React.Component {
       longUnits,
       xAxisLabels
     } = this.state.dataSet;
-    let titleUnits = "";
-    if (showUnits) {
-      titleUnits = " (" + longUnits + ")";
-    }
+
     return (
       <div className={styles.root}>
         <ChartTitle>
-          {title} {titleUnits}
+          {title} {" (" + longUnits + ")"}
         </ChartTitle>
 
         {this.state.dataSet && (

--- a/src/components/sections/TotalProduction/TotalProductionDeprecated.js
+++ b/src/components/sections/TotalProduction/TotalProductionDeprecated.js
@@ -325,7 +325,7 @@ class TotalProductionDeprecated extends React.Component {
 
 	      barSelectedCallback= {this.dataKeySelectedHandler.bind(this, dataSetId, this.state[dataSetId].syncId)}
 
-	      showUnits={true}
+	      showUnits={ (this.state.productionYearlyPeriod === YEARLY_DROPDOWN_VALUES.Fiscal) }
 
 	      >
 	      </StackedBarChartLayout>

--- a/src/components/sections/TotalProduction/TotalProductionDeprecated.js
+++ b/src/components/sections/TotalProduction/TotalProductionDeprecated.js
@@ -325,7 +325,7 @@ class TotalProductionDeprecated extends React.Component {
 
 	      barSelectedCallback= {this.dataKeySelectedHandler.bind(this, dataSetId, this.state[dataSetId].syncId)}
 
-	      showUnits={ (this.state.productionYearlyPeriod === YEARLY_DROPDOWN_VALUES.Fiscal) }
+	      showUnits={ (this.state.productionYearlyPeriod === YEARLY_DROPDOWN_VALUES.Fiscal) && (this.state.productionToggle === TOGGLE_VALUES.Year) ? true : false }
 
 	      >
 	      </StackedBarChartLayout>

--- a/src/components/sections/TotalProduction/TotalProductionDeprecated.js
+++ b/src/components/sections/TotalProduction/TotalProductionDeprecated.js
@@ -325,7 +325,7 @@ class TotalProductionDeprecated extends React.Component {
 
 	      barSelectedCallback= {this.dataKeySelectedHandler.bind(this, dataSetId, this.state[dataSetId].syncId)}
 
-	      showUnits={ (this.state.productionYearlyPeriod === YEARLY_DROPDOWN_VALUES.Fiscal) && (this.state.productionToggle === TOGGLE_VALUES.Year) ? true : false }
+	      showUnits={ ((this.state.productionYearlyPeriod === YEARLY_DROPDOWN_VALUES.Fiscal) && (this.state.productionToggle === TOGGLE_VALUES.Year)) }
 
 	      >
 	      </StackedBarChartLayout>


### PR DESCRIPTION
Fixes #4733

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/double-vision-units/)

Changes proposed in this pull request:

- Fixes duplicate production units
