### PR TITLE
Removes Native American laws link that only links to next section

### DIFF
--- a/src/markdown/how-it-works/default.md
+++ b/src/markdown/how-it-works/default.md
@@ -49,11 +49,6 @@ redirect_from: /how-it-works/production/
             <p>The government reforms laws and regulations by enacting new legislation and proposing new rules for implementation.</p>
             <p><custom-link to="/how-it-works/federal-reforms">Learn about reforms</custom-link></p>
           </div>
-          <div>
-            <h3 class="h3 landing-heading"><custom-link to="/how-it-works/#native-american-overview">Native American laws and regulations</custom-link></h3>
-            <p>Extracting natural resources on Native American land and distributing the associated revenue involves a unique set of processes and stakeholders.</p>
-            <p><custom-link to="/how-it-works/#native-american-overview">Learn about Native American laws</custom-link></p>
-          </div>
         </div>
       </section>
       <section class="container">


### PR DESCRIPTION
Fixes #4563

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/na-governance/how-it-works/#laws)

Changes proposed in this pull request:

- Removes superfluous Native American laws and regulations link that simply links to anchor in the next section
