### PR TITLE
fixed sparkline for revenues, #4489

### DIFF
--- a/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
+++ b/plugins/custom-excel-transformer/data-transformers/revenues-transformer.js
@@ -93,7 +93,7 @@ const createRevenueNode = (revenueData, type) => {
   let year = revenueNode.CalendarYear || revenueNode.FiscalYear
   let month = (revenueNode.Month) ? getMonthFromString(revenueNode.Month) : 0
 
-  revenueNode.RevenueDate = new Date(year, month)
+  revenueNode.RevenueDate = new Date(year, month, 15)
 
   if (revenueNode.LandClass === CONSTANTS.NATIVE_AMERICAN) {
     revenueNode.LandCategory = CONSTANTS.ONSHORE

--- a/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
+++ b/src/components/layouts/charts/StackedBarChartLayout/StackedBarChartLayout.js
@@ -49,7 +49,6 @@ class StackedBarChartLayout extends React.Component {
   }
 
   getChartLegend() {
-    console.log('this.props: ', this.props)
     let {
       legendTitle,
       legendDataFormatFunc,

--- a/src/components/sections/RevenueTrends/RevenueTrends.js
+++ b/src/components/sections/RevenueTrends/RevenueTrends.js
@@ -22,7 +22,6 @@ const TREND_LIMIT = 10
 */
 
 const RevenueTrends = () => {
-
   const data = useStaticQuery(graphql`
           query RevenueTrendsQuery {
         allMonthlyRevenuesByFiscalYear: allResourceRevenuesMonthly(
@@ -45,7 +44,6 @@ const RevenueTrends = () => {
       }
 `)
 
-
   let fiscalYearData = JSON.parse(JSON.stringify(data.allMonthlyRevenuesByFiscalYear.group)).sort((a, b) => (a.fiscalYear < b.fiscalYear) ? 1 : -1)
 
   // Get the latest date then subtract 1 year to filter previous year data to compare current year data
@@ -61,11 +59,13 @@ const RevenueTrends = () => {
             currentYearData.amountByRevenueType.Rents +
             currentYearData.amountByRevenueType['Other Revenues'])
 
-  let trendData = fiscalYearData.splice(0, TREND_LIMIT)
+  // If current fiscal year date is September then we have the full year and we should include it in the trend lines
+  let beginTrendDataLimit = (currentYearDate.getMonth() === 8) ? 0 : 1
+  let trendData = fiscalYearData.splice(beginTrendDataLimit, TREND_LIMIT + beginTrendDataLimit)
 
-  let previousYearData = JSON.parse(JSON.stringify(trendData))[1]
+  let previousYearDataIndex = (beginTrendDataLimit === 0) ? 1 : 0
+  let previousYearData = JSON.parse(JSON.stringify(trendData))[previousYearDataIndex]
   previousYearData.data = previousYearData.data.filter(item => new Date(item.node.RevenueDate) <= previousYearMaxDate)
-
 
   previousYearData = [previousYearData].map(calculateRevenueTypeAmountsByYear)[0]
   calculateOtherRevenues(previousYearData)
@@ -73,7 +73,6 @@ const RevenueTrends = () => {
                               previousYearData.amountByRevenueType.Bonus +
                               previousYearData.amountByRevenueType.Rents +
                               previousYearData.amountByRevenueType['Other Revenues']
-
 
   let currentFiscalYearText = 'FY' + currentYearData.year.slice(2) + ' so far'
   let previousFiscalYearText = 'from FY' + previousYearData.year.slice(2)
@@ -108,7 +107,8 @@ const RevenueTrends = () => {
       <table className={styles.revenueTable}>
         <thead>
           <tr>
-            <th>10-year trend</th>
+            <th>{'FY' + trendData[0].fiscalYear.slice(2) + ' - ' +
+              'FY' + trendData[trendData.length - 1].fiscalYear.slice(2)} trend</th>
             <th className={styles.alignRight}>{currentFiscalYearText}</th>
           </tr>
         </thead>
@@ -210,17 +210,15 @@ const calculateOtherRevenues = data => {
 **/
 
 const calculateRevenueTypeAmountsByYear = (yearData, index) => {
-
   let fiscalYear = yearData.fiscalYear
   let sums = yearData.data.reduce((total, item) => {
     total[item.node.RevenueType] =
       (total[item.node.RevenueType] !== undefined)
         ? total[item.node.RevenueType] + item.node.Revenue
-          : item.node.Revenue
+        : item.node.Revenue
 
     return total
   }, {})
-
 
   return { 'year': fiscalYear, 'amountByRevenueType': sums }
 }

--- a/src/components/sections/RevenueTrends/RevenueTrends.js
+++ b/src/components/sections/RevenueTrends/RevenueTrends.js
@@ -45,11 +45,9 @@ const RevenueTrends = () => {
 `)
 
   let fiscalYearData = JSON.parse(JSON.stringify(data.allMonthlyRevenuesByFiscalYear.group)).sort((a, b) => (a.fiscalYear < b.fiscalYear) ? 1 : -1)
-  console.log(fiscalYearData)
 
   // Get the latest date then subtract 1 year to filter previous year data to compare current year data
   let currentYearDate = new Date(fiscalYearData[0].data[0].node.RevenueDate)
-  console.log(currentYearDate)
   let previousYearMaxDate = new Date(fiscalYearData[0].data[0].node.RevenueDate)
 
   previousYearMaxDate.setFullYear(previousYearMaxDate.getUTCFullYear() - 1)

--- a/src/components/sections/RevenueTrends/RevenueTrends.js
+++ b/src/components/sections/RevenueTrends/RevenueTrends.js
@@ -45,9 +45,11 @@ const RevenueTrends = () => {
 `)
 
   let fiscalYearData = JSON.parse(JSON.stringify(data.allMonthlyRevenuesByFiscalYear.group)).sort((a, b) => (a.fiscalYear < b.fiscalYear) ? 1 : -1)
+  console.log(fiscalYearData)
 
   // Get the latest date then subtract 1 year to filter previous year data to compare current year data
   let currentYearDate = new Date(fiscalYearData[0].data[0].node.RevenueDate)
+  console.log(currentYearDate)
   let previousYearMaxDate = new Date(fiscalYearData[0].data[0].node.RevenueDate)
 
   previousYearMaxDate.setFullYear(previousYearMaxDate.getUTCFullYear() - 1)
@@ -61,7 +63,7 @@ const RevenueTrends = () => {
 
   // If current fiscal year date is September then we have the full year and we should include it in the trend lines
   let beginTrendDataLimit = (currentYearDate.getMonth() === 8) ? 0 : 1
-  let trendData = fiscalYearData.splice(beginTrendDataLimit, TREND_LIMIT + beginTrendDataLimit)
+  let trendData = fiscalYearData.splice(beginTrendDataLimit, TREND_LIMIT)
 
   let previousYearDataIndex = (beginTrendDataLimit === 0) ? 1 : 0
   let previousYearData = JSON.parse(JSON.stringify(trendData))[previousYearDataIndex]

--- a/src/state/reducers/data-sets.js
+++ b/src/state/reducers/data-sets.js
@@ -439,7 +439,6 @@ const dataSetByYear = (id, key, source, filter, options) => {
   longUnits = source[0].data.Units || 'dollars'
 
   results = Object.entries(utils.groupBy(source, getYearKey(source[0].data))).map(e => ({ [e[0]]: e[1] }))
-  console.log(results)
 
   // We assume if its Monthly data and  if the data matches current year that we dont have the year of data, so we remove it
   if (source[0].data.Month) {


### PR DESCRIPTION
Fixes #4489

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/onrr/doi-extractives-data/4489-revenue-trend-line-fix/)

Changes proposed in this pull request:

- Changed the trend line to be the previous 10 years unless the current year is complete
-
-
