### PR TITLE
Restructures homepage subheadings; adds h2

### DIFF
--- a/src/components/layouts/Header/Header.js
+++ b/src/components/layouts/Header/Header.js
@@ -55,10 +55,7 @@ const Header = props => {
       { isIE && <BrowserBanner /> }
       <div className="header-left">
         <Link className="header-image_link" to="/">
-          <h1 className="sr-only">
-            US Department of the Interior Natural Resources Revenue Data
-          </h1>
-          <img className="header-image" src={NRRDLogo} alt="Logo" />
+          <img className="header-image" src={NRRDLogo} alt="U.S. Department of the Interior Natural Resources Revenue Data wordmark with oil platform rig pulling up a dollar sign" />
         </Link>
       </div>
       <MediaQuery maxWidth={768}>

--- a/src/components/layouts/Tabordion/TabContainer.js
+++ b/src/components/layouts/Tabordion/TabContainer.js
@@ -7,9 +7,9 @@ const TabContainer = (props) => {
     return (
 	    <section className={styles.root}>
 	      <div className={styles.contentTop}>
-		<h3 className={styles.title}>
+		<h2 className={styles.title}>
 		  {props.title}
-		</h3>					      
+		</h2>					      
 		<span className={styles.info}>
 		  {props.info}
 		</span>

--- a/src/components/layouts/Tabordion/TabContainer.module.scss
+++ b/src/components/layouts/Tabordion/TabContainer.module.scss
@@ -26,6 +26,7 @@ margin-top: 2rem;
     color: #1C2326;
     text-align: left;
     line-height: 46px;
+    margin: 0 0 .5rem;
 }
     
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -127,6 +127,7 @@ class Beta extends React.Component {
 		</Helmet>
 	  <section className="container-page-wrapper">
       <span className="h3-bar"></span>
+      <h1 class="sr-only">U.S. Department of the Interior Natural Resources Revenue Data</h1>
 		  <p> When companies extract energy and mineral resources on property leased from the federal government and Native Americans, they pay <GlossaryTerm termKey="Bonus">bonuses</GlossaryTerm>, <GlossaryTerm>rent</GlossaryTerm>, and <GlossaryTerm termKey="Royalty">royalties</GlossaryTerm>. The Office of Natural Resources Revenue (ONRR) collects and <GlossaryTerm termKey="disbursement">disburses</GlossaryTerm> revenue from federal lands and waters to different agencies, funds, and local governments for public use. All revenue collected from extraction on Native American lands is disbursed to Native American tribes, nations, or individuals.</p>
 		</section>
 		<Tabordion selected={selected}  >


### PR DESCRIPTION
Fixes #4807

[🐢 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/heading-structure/)

Changes proposed in this pull request:

- Adds `h2` to properly structure subheadings for accessibility and SEO

_The visible presentation of the homepage should be identical to the live site._

- Moves visually hidden `h1` from header component (which is included on every page) to `index.js` to prevent multiple `h1`s appearing on other pages (each page should only have **one** h1).
- Adds `alt` text for wordmark