### PR TITLE
Restores map icon back to state-page template (again)

### DIFF
--- a/src/templates/state-page.js
+++ b/src/templates/state-page.js
@@ -205,6 +205,31 @@ class StatePages extends React.Component {
             <div className="container-right-3 sticky sticky_nav sticky_nav-padded">
               <h3 className="state-page-nav-title container">
                 <div className="nav-title">{this.usStateData.title}</div>
+                <figure is="data-map">
+                <Link to="/explore/" title="Explore data main page">
+                  <svg className = "states map icon" viewBox="22 60 936 525">
+                    <g className ="states features">
+                      <use xlinkHref={withPrefixSVG('/maps/states/all.svg#states')}></use>
+                    </g>
+                    <g className="offshore states features">
+                      <use xlinkHref={withPrefixSVG('/maps/offshore/all.svg#alaska')}></use>
+                    </g>
+                    <g className="offshore states features">
+                      <use xlinkHref={withPrefixSVG('/maps/offshore/all.svg#atlantic')}></use>
+                    </g>
+                    <g className="offshore states features">
+                      <use xlinkHref={withPrefixSVG('/maps/offshore/all.svg#gulf')}></use>
+                    </g>
+                    <g className="offshore states features">
+                      <use xlinkHref={withPrefixSVG('/maps/offshore/all.svg#pacific')}></use>
+                    </g>
+                    <g className="state feature">
+                      <use xlinkHref={withPrefixSVG('/maps/states/all.svg#state-' + this.usStateData.unique_id)}></use>
+                    </g>
+                  </svg>
+                </Link>
+              </figure>
+              <label className="nav-prompt">Explore data main page</label>
               </h3>
               <nav>
                 <NavList navItems={NAV_ITEMS} />


### PR DESCRIPTION
Fixes #3474

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/state-map-icons-again/explore/WY)

Changes proposed in this pull request:

- Adds small map back to state page template above

![Wyoming navigation menu with no map, nav items include Top, Production, Revenue, Disbursements, State Governance](https://user-images.githubusercontent.com/32855580/69360452-6aa6a300-0c3f-11ea-8590-e99a97c7800d.png)

![Wyoming navigation menu with a small map of the United States with Wyoming highlighted, nav items include Top, Production, Revenue, Disbursements, State Governance](https://user-images.githubusercontent.com/32855580/69360430-5d89b400-0c3f-11ea-8295-bc6c8eba3613.png)


