### PR TITLE
Plural in blog title

### DIFF
--- a/blog-site/src/pages/moving-to-database/index.md
+++ b/blog-site/src/pages/moving-to-database/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Finding the limits of static: building a database for natural resource revenue data"
+title: "Finding the limits of static: building a database for natural resources revenue data"
 authors:
 - Mojo Nichols
 - Ryan Johnson


### PR DESCRIPTION


[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-plural/blog)

Changes proposed in this pull request:

- Changes "resource" to "resources" in blog title
