### PR TITLE
Remove extra link syntax on images

### DIFF
--- a/blog-site/src/pages/product-champion/index.md
+++ b/blog-site/src/pages/product-champion/index.md
@@ -14,7 +14,7 @@ Every product needs a champion. We are fortunate to have had one of the best pro
 
 Judy recently moved on because she was selected for a Senior Executive Service (SES) position in the Assistant Secretary, Indian Affairs Office of the Deputy Assistant Secretary, Management as the Director, Office of Facilities, Property and Safety. She was the first product owner of the website and did everything in her power to build our team to the point we’re at today.
 
-[![Photo of Judy Wilson dressed as a super hero](./SuperJudy.jpg)](./SuperJudy.jpg)
+![Photo of Judy Wilson dressed as a super hero](./SuperJudy.jpg)
 
 Judy was an excellent product champion, and we’ve done some reflecting on what makes a good champion in the hopes that it will help people in other agencies replicate some of the magic Judy brought to the Office of Natural Resources Revenue.
 
@@ -54,7 +54,7 @@ Judy was great at managing up. From the beginning, she had the support of the di
 
 Judy was able to make the transition between two administrations feel seamless. She never cared who was in office and continues to work to serve the American public, no matter what. She adjusted some of the messaging to her audience by citing different laws that were enacted by each administration as reasons why the site needed to continue to exist, and as a result, the team and website weren’t affected much by the transition.
 
-[![Photo of Judy Wilson accepting an award from Department Secretary Ryan Zinke](./JudyZinke.png)](./JudyZinke.png)
+![Photo of Judy Wilson accepting an award from Department Secretary Ryan Zinke](./JudyZinke.png)
 
 ## Positioned for success
 


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/blog-post-image-links/blog/product-champion/)

Changes proposed in this pull request:

- Image links are broken on this post, presumably because they are wrapped in extra link syntax
- Removes extra link

![image of woman in captain america costume with 404 indicating broken link](https://user-images.githubusercontent.com/32855580/70641908-30537480-1bf3-11ea-9e4f-6f4a0da64156.png)

