### PR TITLE
Fixes capitalization for proper and common nouns, disbursements trends

### DIFF
--- a/src/components/sections/DisbursmentTrends/DisbursementTrends.js
+++ b/src/components/sections/DisbursmentTrends/DisbursementTrends.js
@@ -227,9 +227,9 @@ const aggregateMonthlyData= (data,currentYear) => {
     let r=[
 	{fund: 'U.S. Treasury', current: 0, previous: 0, histSum: {}, histData:[] },
 	{fund: 'States & counties', current: 0, previous: 0, histSum:{}, histData:[] },
-	{fund: 'Reclamation fund', current: 0, previous: 0, histSum:{}, histData:[]},
+	{fund: 'Reclamation Fund', current: 0, previous: 0, histSum:{}, histData:[]},
 	{fund: 'Native Americans', current: 0, previous: 0, histSum:{}, histData:[]},
-	{fund: 'Other Funds', current: 0, previous: 0, histSum:{}, histData:[]},
+	{fund: 'Other funds', current: 0, previous: 0, histSum:{}, histData:[]},
 	{fund: 'Total', current: 0, previous: 0, histSum: {},histData:[], className : 'strong'}
     ]
 
@@ -284,9 +284,9 @@ const aggregateData= (data) => {
     let r=[
 	{fund: 'U.S. Treasury', current: 0, previous: 0, histSum: {}, histData:[] },
 	{fund: 'States & counties', current: 0, previous: 0, histSum:{}, histData:[] },
-	{fund: 'Reclamation fund', current: 0, previous: 0, histSum:{}, histData:[]},
+	{fund: 'Reclamation Fund', current: 0, previous: 0, histSum:{}, histData:[]},
 	{fund: 'Native Americans', current: 0, previous: 0, histSum:{}, histData:[]},
-	{fund: 'Other Funds', current: 0, previous: 0, histSum:{}, histData:[]},
+	{fund: 'Other funds', current: 0, previous: 0, histSum:{}, histData:[]},
 	{fund: 'Total', current: 0, previous: 0, histSum: {},histData:[], className : 'strong'}
     ]
     let currentYear=data[0].Fiscal_Year


### PR DESCRIPTION
[💹 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/capitalization-fixes/)

Changes proposed in this pull request:

- Changes capitalization in Disbursements trends
  - Changes "Reclamation fund" to "Reclamation Fund" because it's a proper noun
  - Changes "Other Funds" to "Other funds" because it is _not_ a proper noun
