### PR TITLE
Uses 'region' for both offshore production and revenue tables

### DIFF
--- a/src/components/locations/SectionOffshoreRevenue.js
+++ b/src/components/locations/SectionOffshoreRevenue.js
@@ -187,7 +187,7 @@ const SectionOffshoreRevenue = props => {
                             year={commodityYearsSortDesc[0]}>
                             <thead>
                               <tr>
-                                <th>{utils.toTitleCase(usStateData.unique_id)}</th>
+                                <th>{'Region'}</th>
                                 <th colSpan='2' className='numeric' data-series='volume'>Revenue</th>
                               </tr>
                             </thead>


### PR DESCRIPTION
Fixes #2721

[🌎 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/consistent-offshore-label/explore/offshore-pacific/)

Changes proposed in this pull request:

- Applies consistent label for production and revenue tables
