### PR TITLE
Fixes state revenue chart caption

### DIFF
--- a/src/components/locations/SectionRevenue.js
+++ b/src/components/locations/SectionRevenue.js
@@ -172,10 +172,10 @@ const SectionRevenue = props => {
                       </eiti-bar-chart>
                       <figcaption id={'federal-revenue-county-figures-' + allCommoditiesSlug} aria-hidden='false'>
                         <span className="caption-data">
-                          <span className="eiti-bar-chart-y-value" data-format="$,">
+                          Companies paid <span className="eiti-bar-chart-y-value" data-format="$,">
                             {(allCommoditiesValues[commodityYearsSortDesc[0]]) ? (allCommoditiesValues[commodityYearsSortDesc[0]]).toLocaleString() : ('0').toLocaleString() }{' '}
                           </span>
-                            Companies paid{' '}of revenue to produce natural resources on federal land in {' ' + usStateData.title + ' in '}
+                             to produce natural resources on federal land in {' ' + usStateData.title + ' in '}
                           <span className="eiti-bar-chart-x-value">{ commodityYearsSortDesc[0] }</span>.
                         </span>
                         <span className="caption-no-data" aria-hidden="true">

--- a/src/components/locations/SectionRevenue.js
+++ b/src/components/locations/SectionRevenue.js
@@ -179,7 +179,7 @@ const SectionRevenue = props => {
                           <span className="eiti-bar-chart-x-value">{ commodityYearsSortDesc[0] }</span>.
                         </span>
                         <span className="caption-no-data" aria-hidden="true">
-                                                    There is no data about production of {allCommoditiesChartName.toLowerCase()} in{' '}
+                                                    There is no data about revenue from natural resources on federal land in {' ' + usStateData.title + ' in '}
                           <span className="eiti-bar-chart-x-value">{ commodityYearsSortDesc[0] }</span>.
                         </span>
                       </figcaption>

--- a/src/components/locations/SectionRevenue.js
+++ b/src/components/locations/SectionRevenue.js
@@ -175,7 +175,7 @@ const SectionRevenue = props => {
                           <span className="eiti-bar-chart-y-value" data-format="$,">
                             {(allCommoditiesValues[commodityYearsSortDesc[0]]) ? (allCommoditiesValues[commodityYearsSortDesc[0]]).toLocaleString() : ('0').toLocaleString() }{' '}
                           </span>
-                          {' '}of {allCommoditiesChartName.toLowerCase()} were produced on federal land in {' ' + usStateData.title + ' in '}
+                            Companies paid{' '}of revenue to produce natural resources on federal land in {' ' + usStateData.title + ' in '}
                           <span className="eiti-bar-chart-x-value">{ commodityYearsSortDesc[0] }</span>.
                         </span>
                         <span className="caption-no-data" aria-hidden="true">


### PR DESCRIPTION
Fixes #4914

[📊 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/fix-revenue-caption/explore/TX#federal-revenue)

Changes proposed in this pull request:

- State revenue chart wording is currently for production
- This PR reverts that wording back to that for revenue
