### PR TITLE
Added a slash to the home page query tool links

### DIFF
--- a/src/components/sections/TotalDisbursements/TotalDisbursementsDeprecated.js
+++ b/src/components/sections/TotalDisbursements/TotalDisbursementsDeprecated.js
@@ -342,7 +342,7 @@ class TotalDisbursementsDeprecated extends React.Component {
 	      <section className={styles.revenueDisbursementsSection} >
 		  <h3 className={styles.title + ' h3-bar'}>Total disbursements<span className={styles.titleRight}>
 		  <ExploreDataLink
-		    to="/query-data?dataType=Disbursements"
+		    to="/query-data/?dataType=Disbursements"
 	            icon="filter"
 		    >Filter disbursements data
 			    </ExploreDataLink></span></h3>

--- a/src/components/sections/TotalProduction/TotalProductionDeprecated.js
+++ b/src/components/sections/TotalProduction/TotalProductionDeprecated.js
@@ -344,7 +344,7 @@ class TotalProductionDeprecated extends React.Component {
 		  <section className={styles.production} >
 		  <h3 className={styles.title + ' h3-bar'}>Total production<span className={styles.titleRight}>
 		  <ExploreDataLink
-		    to="/query-data?dataType=Production"
+		    to="/query-data/?dataType=Production"
 	            icon="filter"
 		    >Filter production data
 			    </ExploreDataLink></span></h3>

--- a/src/components/sections/TotalRevenue/TotalRevenueDeprecated.js
+++ b/src/components/sections/TotalRevenue/TotalRevenueDeprecated.js
@@ -345,7 +345,7 @@ class TotalRevenueDeprecated extends React.Component {
 
 		  <h3 className={styles.title + ' h3-bar'}>Total revenue<span className={styles.titleRight}>
 		  <ExploreDataLink
-		    to="/query-data?dataType=Revenue"
+		    to="/query-data/?dataType=Revenue"
 	            icon="filter"
 		    >Filter revenue data
 			    </ExploreDataLink></span> </h3>


### PR DESCRIPTION
Fixes #4897

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/onrr/doi-extractives-data/4897-fix-homepage-links/)

Changes proposed in this pull request:

- added back slashes to links
-
-
