### PR TITLE
Release v5.5.4

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ let config = {
   siteMetadata: {
     title: 'Natural Resources Revenue Data',
     description: 'This site provides open data about natural resource management on federal lands and waters in the United States, including oil, gas, coal, and other extractive industries.',
-    version: 'v5.5.3',
+    version: 'v5.5.4',
     googleAnalyticsId: GOOGLE_ANALYTICS_ID,
   },
   plugins: [

--- a/src/components/sections/WhatsNew/WhatsNew.js
+++ b/src/components/sections/WhatsNew/WhatsNew.js
@@ -7,11 +7,11 @@ const WhatsNew = props => (
   <section className={styles.root + ' slab-delta'}>
   	<div className="container-page-wrapper">
       <h2>What's new</h2>
-      <p>In our latest release on January 22, 2020, we made the following changes:</p>
+      <p>In our latest release on February 6, 2020, we made the following changes:</p>
       <ul className="list-bullet ribbon-card-top-list">
-        <li>Added monthly disbursements data for November 2019</li>
-        <li>Added monthly production data for September 2019</li>
-        <li>Added monthly revenue data for December 2019</li>
+        <li>Added calendar year revenue data for 2019</li>
+        <li>Added disbursements data for December 2019</li>
+        <li>Added blog post about being tool agnostic</li>
       </ul>
 
       <p>Review our <a href="https://github.com/ONRR/doi-extractives-data/releases">full release details</a>.</p>


### PR DESCRIPTION


[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/release_v554/)

Changes proposed in this pull request:

- Added calendar year revenue data for 2019 
- Added disbursements data for December 2019 
- Added blog post about being tool agnostic 
- Updated Geothermal label and measurement units 

 
