### PR TITLE
Update coal-excise-tax

### DIFF
--- a/src/markdown/how-it-works/coal-excise-tax.md
+++ b/src/markdown/how-it-works/coal-excise-tax.md
@@ -90,6 +90,11 @@ Coal Excise Tax payments are collected by the Internal Revenue Service and trans
       <td>$224,094,000</td>
       <td><strong>$431,725,000</strong></td>
     </tr>
+    <td>2018</td>
+    <td>$190,356,000</td>
+    <td>$191,773,000</td>
+    <td><strong>$382,129,000</strong></td>
+  </tr>
   </tbody>
 </table>
 
@@ -97,7 +102,7 @@ This data is from federal excise taxes reported to or collected by the Internal 
 
 ## Rates
 
-On January 1, 2019, the tax rate changed from $1.10 per ton for coal from subsurface mines and $0.55 per ton for coal from surface mines. Both rates were limited to a maximum of 4.4% of the coal’s selling price. The new tax rate is $0.50 per ton for coal from subsurface mines and $0.25 per ton for coal from surface mines. Both rates are limited to 2% of the coal's selling price.
+As of January 1, 2020, the tax rate changed back to $1.10 per ton for coal from subsurface mines and $0.55 per ton for coal from surface mines. Both rates are limited to a maximum of 4.4% of the coal’s selling price. In 2019, the tax rate was $0.50 per ton for coal from subsurface mines and $0.25 per ton for coal from surface mines. Both rates were limited to 2% of the coal's selling price.
 
 <table class="article_table">
   <thead>
@@ -110,14 +115,14 @@ On January 1, 2019, the tax rate changed from $1.10 per ton for coal from subsur
     <tr>
       <td>Surface mining</td>
       <td>
-          $0.25 per ton or 2% of the sales price<br>
+          $0.55 per ton or 4.4% of the sales price<br>
           (whichever is lower)
       </td>
     </tr>
     <tr>
       <td>Subsurface mining</td>
       <td>
-          $0.50 per ton or 2% of the sales price<br>
+          $1.10 per ton or 4.4% of the sales price<br>
           (whichever is lower)
       </td>
     </tr>


### PR DESCRIPTION
Fixes #4958

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/onrr/doi-extractives-data/coal_excise_tax_update/)

Changes proposed in this pull request:

- updates coal excise tax to 2018 rates 

Here is the Further Consolidated Appropriations Act, 2020 that amends the law below to extend through December 31, 2020 instead of December 31, 2018. 

https://www.congress.gov/bill/116th-congress/house-bill/1865/text#toc-H0AC10BAAB0B34E5E88C28AB1720B6600

https://uscode.house.gov/view.xhtml?req=(title:26%20section:4121%20edition:prelim)
- updates revenue table to include 2018 revenue - can check data using IRS link on the site

